### PR TITLE
Made the jsmpp jar as an OSGi bundle

### DIFF
--- a/jsmpp/pom.xml
+++ b/jsmpp/pom.xml
@@ -6,7 +6,7 @@
         <version>2.2.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
 
     <artifactId>jsmpp</artifactId>
 
@@ -35,6 +35,24 @@
                         <suiteXmlFile>testng.xml</suiteXmlFile>
                     </suiteXmlFiles>
                 </configuration>
+            </plugin>
+            <plugin>
+              <groupId>org.apache.felix</groupId>
+              <artifactId>maven-bundle-plugin</artifactId>
+              <extensions>true</extensions>
+              <configuration>
+                <instructions>
+                  <Bundle-Name>${project.artifactId}</Bundle-Name>
+                  <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+                  <Export-Package>org.jsmpp</Export-Package>
+                  <Import-Package>
+                    org.slf4j;resolution:=optional,
+                    *
+                  </Import-Package>
+                  <Implementation-Title>jsmpp</Implementation-Title>
+                  <Implementation-Version>${project.version}</Implementation-Version>
+                </instructions>
+              </configuration>
             </plugin>
             <plugin>
                 <groupId>pl.project13.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,11 @@
                     <version>2.1</version>
                 </plugin>
                 <plugin>
+                  <groupId>org.apache.felix</groupId>
+                  <artifactId>maven-bundle-plugin</artifactId>
+                  <version>2.3.7</version>
+                </plugin>
+                <plugin>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>2.1.2</version>
                     <executions>


### PR DESCRIPTION
With the help of maven-bundle-plugin it's easy to create an OSGi bundle and we don't need to maintain two jsmpp artifacts. 