### PR TITLE
SMPP 3.4 Relative Time Format

### DIFF
--- a/jsmpp/src/test/java/org/jsmpp/util/DateFormatterTest.java
+++ b/jsmpp/src/test/java/org/jsmpp/util/DateFormatterTest.java
@@ -14,130 +14,102 @@
  */
 package org.jsmpp.util;
 
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import static org.testng.Assert.*;
-
 import org.testng.annotations.Test;
 
 
 /**
  * @author uudashr
- *
  */
 public class DateFormatterTest {
-    
-    @Test(groups="checkintest")
-    public void testStaticAbsoluteFormatter() {
-        String formatted = AbsoluteTimeFormatter.format(07, 12, 26, 11, 37, 03, 8, 45, '+');
-        assertEquals(formatted, "071226113703845+");
-    }
-    
-    @Test(groups="checkintest")
-    public void testStaticRelativeFormatter() {
-        String formatted = RelativeTimeFormatter.format(07, 12, 26, 12, 46, 10);
-        assertEquals(formatted, "071226124610000R");
-    }
-    
-    @Test(groups="checkintest")
-    public void formatNullDate() {
-        TimeFormatter timeFormatter = new AbsoluteTimeFormatter();
-        assertNull(timeFormatter.format((Date)null));
-        assertNull(timeFormatter.format((Calendar)null));
-        
-        timeFormatter = new RelativeTimeFormatter();
-        assertNull(timeFormatter.format((Date)null));
-        assertNull(timeFormatter.format((Calendar)null));
-    }
-    
-    @Test(groups="checkintest")
-    public void validateAbsoluteDate() throws Exception {
-        String formatted = AbsoluteTimeFormatter.format(07, 12, 26, 11, 37, 03, 8, 45, '+');
-        StringValidator.validateString(formatted, StringParameter.SCHEDULE_DELIVERY_TIME);
-        StringValidator.validateString(formatted, StringParameter.VALIDITY_PERIOD);
-        StringValidator.validateString(formatted, StringParameter.FINAL_DATE);
-    }
-    
-    @Test(groups="checkintest")
-    public void validateRelativeDate() throws Exception {
-        String formatted = RelativeTimeFormatter.format(07, 12, 26, 12, 46, 10);
-        StringValidator.validateString(formatted, StringParameter.SCHEDULE_DELIVERY_TIME);
-        StringValidator.validateString(formatted, StringParameter.VALIDITY_PERIOD);
-        StringValidator.validateString(formatted, StringParameter.FINAL_DATE);
-    }
 
-    @Test(groups="checkintest")
-    public void formatAbsoluteDate() {
-        TimeFormatter timeFormatter = new AbsoluteTimeFormatter();
+  @Test(groups = "checkintest")
+  public void testStaticAbsoluteFormatter() {
+    String formatted = AbsoluteTimeFormatter.format(07, 12, 26, 11, 37, 03, 8, 45, '+');
+    assertEquals(formatted, "071226113703845+");
+  }
 
-        GregorianCalendar date = new GregorianCalendar(TimeZone.getTimeZone("Europe/Berlin"), Locale.GERMANY);
-        date.set(Calendar.YEAR, 2013);
-        date.set(Calendar.MONTH, Calendar.JANUARY);
-        date.set(Calendar.DAY_OF_MONTH, 1);
-        date.set(Calendar.HOUR_OF_DAY, 1);
-        date.set(Calendar.MINUTE, 0);
-        date.set(Calendar.SECOND, 0);
-        date.set(Calendar.MILLISECOND, 0);
+  @Test(groups = "checkintest")
+  public void testStaticRelativeFormatter() {
+    String formatted = RelativeTimeFormatter.format(07, 12, 26, 12, 46, 10);
+    assertEquals(formatted, "071226124610000R");
+  }
 
-        assertEquals(timeFormatter.format(date), "130101010000004+");
+  @Test(groups = "checkintest")
+  public void formatNullDate() {
+    TimeFormatter timeFormatter = new AbsoluteTimeFormatter();
+    assertNull(timeFormatter.format((Date) null));
+    assertNull(timeFormatter.format((Calendar) null));
 
-        date.set(Calendar.MONTH, Calendar.JULY);
+    timeFormatter = new RelativeTimeFormatter();
+    assertNull(timeFormatter.format((Date) null));
+    assertNull(timeFormatter.format((Calendar) null));
+  }
 
-        // because of daylight saving time, we have a different offset
-        assertEquals(timeFormatter.format(date), "130701010000008+");
-    }
+  @Test(groups = "checkintest")
+  public void validateAbsoluteDate() throws Exception {
+    String formatted = AbsoluteTimeFormatter.format(07, 12, 26, 11, 37, 03, 8, 45, '+');
+    StringValidator.validateString(formatted, StringParameter.SCHEDULE_DELIVERY_TIME);
+    StringValidator.validateString(formatted, StringParameter.VALIDITY_PERIOD);
+    StringValidator.validateString(formatted, StringParameter.FINAL_DATE);
+  }
 
-    @Test(groups="checkintest")
-    public void formatAbsoluteDateRussia() {
-        TimeFormatter timeFormatter = new AbsoluteTimeFormatter();
+  @Test(groups = "checkintest")
+  public void validateRelativeDate() throws Exception {
+    String formatted = RelativeTimeFormatter.format(07, 12, 26, 12, 46, 10);
+    StringValidator.validateString(formatted, StringParameter.SCHEDULE_DELIVERY_TIME);
+    StringValidator.validateString(formatted, StringParameter.VALIDITY_PERIOD);
+    StringValidator.validateString(formatted, StringParameter.FINAL_DATE);
+  }
 
-        GregorianCalendar date = new GregorianCalendar(TimeZone.getTimeZone("Asia/Yekaterinburg"), new Locale("ru", "RU"));
-        date.set(Calendar.YEAR, 2013);
-        date.set(Calendar.MONTH, Calendar.JANUARY);
-        date.set(Calendar.DAY_OF_MONTH, 1);
-        date.set(Calendar.HOUR_OF_DAY, 1);
-        date.set(Calendar.MINUTE, 0);
-        date.set(Calendar.SECOND, 0);
-        date.set(Calendar.MILLISECOND, 0);
+  @Test(groups = "checkintest")
+  public void formatAbsoluteDate() {
+    TimeFormatter timeFormatter = new AbsoluteTimeFormatter();
 
-        assertEquals(timeFormatter.format(date), "130101010000024+");
+    GregorianCalendar date = new GregorianCalendar(TimeZone.getTimeZone("Europe/Berlin"), Locale.GERMANY);
+    date.set(Calendar.YEAR, 2013);
+    date.set(Calendar.MONTH, Calendar.JANUARY);
+    date.set(Calendar.DAY_OF_MONTH, 1);
+    date.set(Calendar.HOUR_OF_DAY, 1);
+    date.set(Calendar.MINUTE, 0);
+    date.set(Calendar.SECOND, 0);
+    date.set(Calendar.MILLISECOND, 0);
 
-        date.set(Calendar.MONTH, Calendar.JULY);
+    assertEquals(timeFormatter.format(date), "130101010000004+");
 
-        // we have the same offset because of the absent of daylight saving time
-        assertEquals(timeFormatter.format(date), "130701010000024+");
-    }
+    date.set(Calendar.MONTH, Calendar.JULY);
 
-    @Test(groups="checkintest",enabled=false) // FIXME - enable again after fixing issues below
-    public void formatRelativeDate() {
-        RelativeTimeFormatter timeFormatter = new RelativeTimeFormatter(TimeZone.getTimeZone("America/Denver"));
+    // because of daylight saving time, we have a different offset
+    assertEquals(timeFormatter.format(date), "130701010000008+");
+  }
 
-        // at this date neither Denver nor Germany has daylight saving time
-        GregorianCalendar date = new GregorianCalendar(TimeZone.getTimeZone("Europe/Berlin"), Locale.GERMANY);
-        date.set(Calendar.YEAR, 2013);
-        date.set(Calendar.MONTH, Calendar.JANUARY);
-        date.set(Calendar.DAY_OF_MONTH, 1);
-        date.set(Calendar.HOUR_OF_DAY, 1);
-        date.set(Calendar.MINUTE, 0);
-        date.set(Calendar.SECOND, 0);
-        date.set(Calendar.MILLISECOND, 0);
+  @Test(groups = "checkintest")
+  public void formatAbsoluteDateRussia() {
+    TimeFormatter timeFormatter = new AbsoluteTimeFormatter();
 
-        assertEquals(timeFormatter.format(date), "130101050000000R"); // FIXME - should be a relative time but looks like an absolute value
-        
-        // at this date Denver has already daylight saving time but not Germany
-        date.set(Calendar.MONTH, Calendar.MARCH);
-        date.set(Calendar.DAY_OF_MONTH, 20);
-        
-        assertEquals(timeFormatter.format(date), "130320060000000R"); // FIXME - should be a relative time but looks like an absolute value
+    GregorianCalendar date = new GregorianCalendar(TimeZone.getTimeZone("Asia/Yekaterinburg"), new Locale("ru", "RU"));
+    date.set(Calendar.YEAR, 2013);
+    date.set(Calendar.MONTH, Calendar.JANUARY);
+    date.set(Calendar.DAY_OF_MONTH, 1);
+    date.set(Calendar.HOUR_OF_DAY, 1);
+    date.set(Calendar.MINUTE, 0);
+    date.set(Calendar.SECOND, 0);
+    date.set(Calendar.MILLISECOND, 0);
 
-        // at this date Denver and Germany has daylight saving time
-        date.set(Calendar.MONTH, Calendar.APRIL);
-        date.set(Calendar.DAY_OF_MONTH, 1);
+    assertEquals(timeFormatter.format(date), "130101010000024+");
 
-        assertEquals(timeFormatter.format(date), "130401050000000R"); // FIXME - should be a relative time but looks like an absolute value
-    }
+    date.set(Calendar.MONTH, Calendar.JULY);
+
+    // we have the same offset because of the absent of daylight saving time
+    assertEquals(timeFormatter.format(date), "130701010000024+");
+  }
+
 }

--- a/jsmpp/src/test/java/org/jsmpp/util/RelativeTimeFormatterTest.java
+++ b/jsmpp/src/test/java/org/jsmpp/util/RelativeTimeFormatterTest.java
@@ -1,0 +1,181 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package org.jsmpp.util;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.fail;
+
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.TimeZone;
+
+import org.testng.annotations.Test;
+
+/**
+ * @author pmoerenhout
+ */
+public class RelativeTimeFormatterTest {
+
+  @Test(groups = "checkintest")
+  public void testStaticRelativeFormatter() {
+    String formatted = RelativeTimeFormatter.format(07, 12, 26, 12, 46, 10);
+    assertEquals(formatted, "071226124610000R");
+  }
+
+  @Test(groups = "checkintest")
+  public void formatNullDate() {
+    TimeFormatter timeFormatter = new RelativeTimeFormatter();
+    assertNull(timeFormatter.format((Date) null));
+    assertNull(timeFormatter.format((Calendar) null));
+  }
+
+  @Test(groups = "checkintest")
+  public void validateRelativeDate() throws Exception {
+    String formatted = RelativeTimeFormatter.format(07, 12, 26, 12, 46, 10);
+    StringValidator.validateString(formatted, StringParameter.SCHEDULE_DELIVERY_TIME);
+    StringValidator.validateString(formatted, StringParameter.VALIDITY_PERIOD);
+    StringValidator.validateString(formatted, StringParameter.FINAL_DATE);
+  }
+
+  @Test(groups = "checkintest", expectedExceptions = IllegalArgumentException.class)
+  public void formatRelativeDateWhenAlreadyPast() {
+    RelativeTimeFormatter timeFormatter = new RelativeTimeFormatter();
+
+    // date in the past
+    GregorianCalendar date = new GregorianCalendar(TimeZone.getTimeZone("Europe/Berlin"));
+    date.set(Calendar.YEAR, 1998);
+    date.set(Calendar.MONTH, Calendar.MARCH);
+    date.set(Calendar.DAY_OF_MONTH, 1);
+    date.set(Calendar.HOUR, 13);
+    date.set(Calendar.MINUTE, 46);
+    date.set(Calendar.SECOND, 59);
+
+    timeFormatter.format(date);
+    fail("Expected IllegalArgumentException not thrown");
+  }
+
+  @Test(groups = "checkintest", expectedExceptions = IllegalArgumentException.class)
+  public void formatRelativeDateIgnoreMilliSeconds() {
+    RelativeTimeFormatter timeFormatter = new RelativeTimeFormatter();
+
+    // Set the SMSC date
+    GregorianCalendar smscDate = new GregorianCalendar(TimeZone.getTimeZone("Europe/Berlin"));
+    smscDate.set(Calendar.YEAR, 1998);
+    smscDate.set(Calendar.MONTH, Calendar.JANUARY);
+    smscDate.set(Calendar.DAY_OF_MONTH, 1);
+    smscDate.set(Calendar.HOUR, 13);
+    smscDate.set(Calendar.MINUTE, 46);
+    smscDate.set(Calendar.SECOND, 59);
+
+    GregorianCalendar date = new GregorianCalendar(TimeZone.getTimeZone("Europe/Berlin"));
+    date.setTimeInMillis(smscDate.getTimeInMillis());
+    // Tenth of seconds should be ignored
+    smscDate.set(Calendar.MILLISECOND, 800);
+
+    assertEquals(timeFormatter.format(date, smscDate), "000000000000000R");
+  }
+
+  @Test(groups = "checkintest", expectedExceptions = IllegalArgumentException.class)
+  public void formatRelativeDateWhenExceedsCentury() {
+    RelativeTimeFormatter timeFormatter = new RelativeTimeFormatter();
+
+    // relative date more then 100 years ahead
+    Calendar date = Calendar.getInstance(TimeZone.getTimeZone("America/Denver"));
+    date.add(Calendar.YEAR, 101);
+
+    String relativeTime = timeFormatter.format(date);
+    fail("Expected IllegalArgumentException not thrown");
+  }
+
+  @Test(groups = "checkintest")
+  public void formatRelativeDateSame() {
+    RelativeTimeFormatter timeFormatter = new RelativeTimeFormatter();
+
+    GregorianCalendar date = new GregorianCalendar(TimeZone.getTimeZone("America/Denver"));
+    assertEquals(timeFormatter.format(date, date), "000000000000000R");
+  }
+
+  @Test(groups = "checkintest")
+  public void formatRelativeDateDifferentTimeZone() {
+    RelativeTimeFormatter timeFormatter = new RelativeTimeFormatter();
+    GregorianCalendar smscDate = new GregorianCalendar(TimeZone.getTimeZone("America/Denver"));
+    smscDate.set(2014, Calendar.JANUARY, 2, 23, 15, 16);
+    GregorianCalendar date = new GregorianCalendar(TimeZone.getTimeZone("America/Los_Angeles"));
+    date.set(2014, Calendar.JANUARY, 2, 23, 15, 16);
+    assertEquals(timeFormatter.format(date, smscDate), "000000010000000R");
+  }
+
+  @Test(groups = "checkintest")
+  public void formatRelativeDateMonth() {
+    RelativeTimeFormatter timeFormatter = new RelativeTimeFormatter();
+    Calendar smscDate = Calendar.getInstance(TimeZone.getTimeZone("America/Denver"));
+
+    GregorianCalendar date = new GregorianCalendar(TimeZone.getTimeZone("America/Denver"));
+    date.setTimeInMillis(smscDate.getTimeInMillis());
+    date.add(Calendar.MONTH, 1);
+    assertEquals(timeFormatter.format(date, smscDate), "000100000000000R");
+  }
+
+  @Test(groups = "checkintest")
+  public void formatRelativeDateWeek() {
+    RelativeTimeFormatter timeFormatter = new RelativeTimeFormatter();
+    GregorianCalendar smscDate = new GregorianCalendar(TimeZone.getTimeZone("America/Denver"));
+
+    GregorianCalendar date = new GregorianCalendar(TimeZone.getTimeZone("America/Denver"));
+    date.setTimeInMillis(smscDate.getTimeInMillis());
+    date.add(Calendar.DAY_OF_MONTH, 7);
+    assertEquals(timeFormatter.format(date, smscDate), "000007000000000R");
+  }
+
+  @Test(groups = "checkintest")
+  public void formatRelativeTimeSecond() {
+    RelativeTimeFormatter timeFormatter = new RelativeTimeFormatter();
+    GregorianCalendar smscDate = new GregorianCalendar(TimeZone.getTimeZone("America/Denver"));
+
+    GregorianCalendar date = new GregorianCalendar(TimeZone.getTimeZone("America/Denver"));
+    date.setTimeInMillis(smscDate.getTimeInMillis());
+    date.add(Calendar.SECOND, 1);
+    assertEquals(timeFormatter.format(date, smscDate), "000000000001000R");
+  }
+
+  @Test(groups = "checkintest")
+  public void formatRelativeTimeMonth() {
+    RelativeTimeFormatter timeFormatter = new RelativeTimeFormatter();
+    GregorianCalendar smscDate = new GregorianCalendar(TimeZone.getTimeZone("America/Denver"));
+    smscDate.set(2001, Calendar.JANUARY, 31, 14, 15, 16);
+
+    GregorianCalendar date = new GregorianCalendar(TimeZone.getTimeZone("America/Denver"));
+    date.setTimeInMillis(smscDate.getTimeInMillis());
+    date.add(Calendar.MONTH, 1);
+    // when using Joda-Time or Java 8 Period class
+    //assertEquals(timeFormatter.format(date), "000100000000000R");
+    assertEquals(timeFormatter.format(date, smscDate), "000028000000000R");
+  }
+
+  @Test(groups = "checkintest")
+  public void formatRelativeDateNewYear() {
+    RelativeTimeFormatter timeFormatter = new RelativeTimeFormatter();
+    GregorianCalendar smscDate = new GregorianCalendar(TimeZone.getTimeZone("America/Denver"));
+    smscDate.set(2001, Calendar.DECEMBER, 31, 23, 59, 59);
+
+    GregorianCalendar date = new GregorianCalendar(TimeZone.getTimeZone("Europe/Berlin"));
+    date.setTimeInMillis(smscDate.getTimeInMillis());
+    date.add(Calendar.SECOND, 2);
+    assertEquals(timeFormatter.format(date, smscDate), "000000000002000R");
+  }
+
+}

--- a/jsmpp/src/test/java/org/jsmpp/util/RelativeTimeFormatterTest.java
+++ b/jsmpp/src/test/java/org/jsmpp/util/RelativeTimeFormatterTest.java
@@ -72,9 +72,9 @@ public class RelativeTimeFormatterTest {
   public void formatRelativeDateIgnoreMilliSeconds() {
     RelativeTimeFormatter timeFormatter = new RelativeTimeFormatter();
 
-    // Set the SMSC date
+    // Set the SMSC date to some future datetime
     GregorianCalendar smscDate = new GregorianCalendar(TimeZone.getTimeZone("Europe/Berlin"));
-    smscDate.set(Calendar.YEAR, 1998);
+    smscDate.set(Calendar.YEAR, 2080);
     smscDate.set(Calendar.MONTH, Calendar.JANUARY);
     smscDate.set(Calendar.DAY_OF_MONTH, 1);
     smscDate.set(Calendar.HOUR, 13);

--- a/jsmpp/src/test/java/org/jsmpp/util/RelativeTimeFormatterTest.java
+++ b/jsmpp/src/test/java/org/jsmpp/util/RelativeTimeFormatterTest.java
@@ -68,7 +68,7 @@ public class RelativeTimeFormatterTest {
     fail("Expected IllegalArgumentException not thrown");
   }
 
-  @Test(groups = "checkintest", expectedExceptions = IllegalArgumentException.class)
+  @Test(groups = "checkintest")
   public void formatRelativeDateIgnoreMilliSeconds() {
     RelativeTimeFormatter timeFormatter = new RelativeTimeFormatter();
 

--- a/jsmpp/src/test/java/org/jsmpp/util/RelativeTimeFormatterTest.java
+++ b/jsmpp/src/test/java/org/jsmpp/util/RelativeTimeFormatterTest.java
@@ -84,7 +84,7 @@ public class RelativeTimeFormatterTest {
     GregorianCalendar date = new GregorianCalendar(TimeZone.getTimeZone("Europe/Berlin"));
     date.setTimeInMillis(smscDate.getTimeInMillis());
     // Tenth of seconds should be ignored
-    smscDate.set(Calendar.MILLISECOND, 800);
+    date.set(Calendar.MILLISECOND, 800);
 
     assertEquals(timeFormatter.format(date, smscDate), "000000000000000R");
   }


### PR DESCRIPTION
Implement the SMPP 3.4 Relative Time Format. Separated the Absolute and Relative Time Format tests.