### PR TITLE
NullPointerException when optionalParameters is null in bind response from SMSC

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/bean/BindResp.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/BindResp.java
@@ -58,12 +58,12 @@ public class BindResp extends Command {
     
     public <U extends OptionalParameter> U getOptionalParameter(Class<U> tagClass)
     {
-    	return OptionalParameters.get(tagClass, optionalParameters);
+    	return optionalParameters != null ? OptionalParameters.get(tagClass, optionalParameters) : null;
     }
     
     public OptionalParameter getOptionalParameter(Tag tagEnum)
     {
-    	return OptionalParameters.get(tagEnum.code(), optionalParameters);
+    	return optionalParameters != null ? OptionalParameters.get(tagEnum.code(), optionalParameters) : null;
     }
     
     public OptionalParameter[] getOptionalParameters() {


### PR DESCRIPTION
This pull request fixes issue #7 
There might be a prettier or better way to do this, but I added this fix temporarely in my build to be able to run my code in a test environment. It only works in production without this fix.

