### PR TITLE
Remove enquireLinkSender.join() during session.close() because this p…

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/DefaultPDUSender.java
+++ b/jsmpp/src/main/java/org/jsmpp/DefaultPDUSender.java
@@ -297,11 +297,12 @@ public class DefaultPDUSender implements PDUSender {
     /*
      * (non-Javadoc)
      * 
-     * @see org.jsmpp.PDUSender#sendDeliverSmResp(java.io.OutputStream, int)
+     * @see org.jsmpp.PDUSender#sendDeliverSmResp(java.io.OutputStream, int, int, String)
      */
-    public byte[] sendDeliverSmResp(OutputStream os, int commandStatus, int sequenceNumber)
+    @Override
+    public byte[] sendDeliverSmResp(OutputStream os, int commandStatus, int sequenceNumber, String messageId)
             throws IOException {
-        byte[] b = pduComposer.deliverSmResp(commandStatus, sequenceNumber);
+        byte[] b = pduComposer.deliverSmResp(commandStatus, sequenceNumber, messageId);
         writeAndFlush(os, b);
         return b;
     }

--- a/jsmpp/src/main/java/org/jsmpp/PDUSender.java
+++ b/jsmpp/src/main/java/org/jsmpp/PDUSender.java
@@ -277,7 +277,7 @@ public interface PDUSender {
      * @return the composed bytes.
      * @throws IOException if there is an IO error occur.
      */
-    byte[] sendDeliverSmResp(OutputStream os, int commandStatus, int sequenceNumber)
+    byte[] sendDeliverSmResp(OutputStream os, int commandStatus, int sequenceNumber, String messageId)
             throws IOException;
 
     /**

--- a/jsmpp/src/main/java/org/jsmpp/SynchronizedPDUSender.java
+++ b/jsmpp/src/main/java/org/jsmpp/SynchronizedPDUSender.java
@@ -272,10 +272,10 @@ public class SynchronizedPDUSender implements PDUSender {
         }
     }
 
-    public byte[] sendDeliverSmResp(OutputStream os, int commandStatus, int sequenceNumber)
+    public byte[] sendDeliverSmResp(OutputStream os, int commandStatus, int sequenceNumber, String messageId)
             throws IOException {
         synchronized (os) {
-            return pduSender.sendDeliverSmResp(os, commandStatus, sequenceNumber);
+            return pduSender.sendDeliverSmResp(os, commandStatus, sequenceNumber, messageId);
         }
     }
 

--- a/jsmpp/src/main/java/org/jsmpp/bean/DeliverSm.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/DeliverSm.java
@@ -22,7 +22,17 @@ import org.jsmpp.util.InvalidDeliveryReceiptException;
  *
  */
 public class DeliverSm extends MessageRequest {
-    
+
+	private String id;
+
+	public String getId() {
+		return id;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
 	public DeliverSm() {
 		super();
 	}

--- a/jsmpp/src/main/java/org/jsmpp/session/AbstractSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/AbstractSession.java
@@ -210,19 +210,6 @@ public abstract class AbstractSession implements Session {
             }
         }
 
-        // Make sure the enquireLinkThread doesn't wait for itself
-        if (Thread.currentThread() != enquireLinkSender) {
-            if (enquireLinkSender != null) {
-                while(enquireLinkSender.isAlive()) {
-                    try {
-                        enquireLinkSender.join();
-                    } catch (InterruptedException e) {
-                        logger.warn("interrupted while waiting for enquireLinkSender thread to exit");
-                    }
-                }
-            }
-        }
-
         logger.info("AbstractSession.close() done");
     }
 

--- a/jsmpp/src/main/java/org/jsmpp/session/DefaultSMPPClientOperation.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/DefaultSMPPClientOperation.java
@@ -166,8 +166,11 @@ public class DefaultSMPPClientOperation extends AbstractSMPPOperation implements
         executeSendCommand(replaceSmTask, getTransactionTimer());
     }
 
-    public void deliverSmResp(int sequenceNumber) throws IOException {
+    @Override
+    public void deliverSmResp(int sequenceNumber, String messageId) throws IOException {
         pduSender().sendDeliverSmResp(connection().getOutputStream(),
-                0, sequenceNumber);
+                0, sequenceNumber, messageId);
+
     }
+
 }

--- a/jsmpp/src/main/java/org/jsmpp/session/ResponseHandler.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/ResponseHandler.java
@@ -46,7 +46,7 @@ public interface ResponseHandler extends BaseResponseHandler {
      * @param sequenceNumber is the sequence number of original <b>DELIVER_SM</b> request.
      * @throws IOException if an IO error occur.
      */
-    void sendDeliverSmResp(int commandStatus, int sequenceNumber) throws IOException;
-    
+    void sendDeliverSmResp(int commandStatus, int sequenceNumber, String messageId) throws IOException;
+
     void processAlertNotification(AlertNotification alertNotification);
 }

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPClientOperation.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPClientOperation.java
@@ -88,5 +88,6 @@ public interface SMPPClientOperation extends SMPPOperation {
             byte[] shortMessage) throws PDUException, ResponseTimeoutException,
             InvalidResponseException, NegativeResponseException, IOException;
 
-    void deliverSmResp(int sequenceNumber) throws IOException;
+    void deliverSmResp(int sequenceNumber, String messageId) throws IOException;
+
 }

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
@@ -531,9 +531,10 @@ public class SMPPSession extends AbstractSession implements ClientSession {
 		public void notifyUnbonded() {
 		    sessionContext.unbound();
 		}
-		
-		public void sendDeliverSmResp(int commandStatus, int sequenceNumber) throws IOException {
-			pduSender().sendDeliverSmResp(out, commandStatus, sequenceNumber);
+
+		@Override
+		public void sendDeliverSmResp(int commandStatus, int sequenceNumber, String messageId) throws IOException {
+			pduSender().sendDeliverSmResp(out, commandStatus, sequenceNumber, messageId);
 			logger.debug("deliver_sm_resp with seq_number " + sequenceNumber + " has been sent");
 		}
 		

--- a/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionBoundRX.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionBoundRX.java
@@ -107,14 +107,14 @@ class SMPPSessionBoundRX extends SMPPSessionBound implements SMPPSessionState {
         try {
             DeliverSm deliverSm = pduDecomposer.deliverSm(pdu);
             responseHandler.processDeliverSm(deliverSm);
-            responseHandler.sendDeliverSmResp(0, pduHeader.getSequenceNumber());
+            responseHandler.sendDeliverSmResp(0, pduHeader.getSequenceNumber(), deliverSm.getId());
         } catch (PDUStringException e) {
             logger.error("Failed decomposing deliver_sm", e);
             responseHandler.sendGenerickNack(e.getErrorCode(), pduHeader
                     .getSequenceNumber());
         } catch (ProcessRequestException e) {
             logger.error("Failed processing deliver_sm", e);
-            responseHandler.sendDeliverSmResp(e.getErrorCode(), pduHeader.getSequenceNumber());
+            responseHandler.sendDeliverSmResp(e.getErrorCode(), pduHeader.getSequenceNumber(), null);
         }
     }
     

--- a/jsmpp/src/main/java/org/jsmpp/util/DefaultComposer.java
+++ b/jsmpp/src/main/java/org/jsmpp/util/DefaultComposer.java
@@ -352,12 +352,13 @@ public class DefaultComposer implements PDUComposer {
     /*
      * (non-Javadoc)
      * 
-     * @see org.jsmpp.util.PDUComposer#deliverSmResp(int)
+     * @see org.jsmpp.util.PDUComposer#deliverSmResp(int, int, String)
      */
-    public byte[] deliverSmResp(int commandStatus, int sequenceNumber) {
+    @Override
+    public byte[] deliverSmResp(int commandStatus, int sequenceNumber, String messageId) {
         PDUByteBuffer buf = new PDUByteBuffer(SMPPConstant.CID_DELIVER_SM_RESP,
-        		commandStatus, sequenceNumber);
-        buf.append((String)null);
+                commandStatus, sequenceNumber);
+        buf.append(messageId);
         return buf.toBytes();
     }
 

--- a/jsmpp/src/main/java/org/jsmpp/util/PDUComposer.java
+++ b/jsmpp/src/main/java/org/jsmpp/util/PDUComposer.java
@@ -118,7 +118,7 @@ public interface PDUComposer {
             byte registeredDelivery, byte dataCoding, byte[] shortMessage,
             OptionalParameter... optionalParameters) throws PDUStringException;
 
-    byte[] deliverSmResp(int commandStatus, int sequenceNumber);
+    byte[] deliverSmResp(int commandStatus, int sequenceNumber, String messageId);
 
     /**
      * Compose data short message (data_sm) PDU.


### PR DESCRIPTION
Remove enquireLinkSender.join() during session.close() because this prevents normal closing of session and sessions hangs when smpp server is restarted
