### PR TITLE
squid:S1118 - Utility classes should not have public constructor

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/bean/DataCodings.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/DataCodings.java
@@ -43,7 +43,11 @@ public final class DataCodings {
      */
     public static final DataCoding ZERO = new GeneralDataCoding();
     private static DataCoding[] dataCodingCache = new DataCoding[255];
-    
+
+    private DataCodings() {
+        throw new InstantiationError("This class must not be instantiated");
+    }
+
     /**
      * Create new instance of {@link DataCoding}.
      * 

--- a/jsmpp/src/main/java/org/jsmpp/bean/LongSMS.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/LongSMS.java
@@ -30,6 +30,10 @@ public class LongSMS {
     private final static byte UDHIE_SAR_LENGTH = 0x04;
     private static int referenceNumber = 0;
 
+    private LongSMS() {
+        throw new InstantiationError("This class must not be instantiated");
+    }
+
     private static synchronized int getReferenceNumber() {
         referenceNumber++;
         if (referenceNumber >= 65536)

--- a/jsmpp/src/main/java/org/jsmpp/bean/OptionalParameters.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/OptionalParameters.java
@@ -31,6 +31,11 @@ import org.slf4j.LoggerFactory;
 public class OptionalParameters {
 
     private static final Logger logger = LoggerFactory.getLogger(OptionalParameters.class);
+
+    private OptionalParameters() {
+        throw new InstantiationError("This class must not be instantiated");
+    }
+
     /**
      * Create SAR_MESSAGE_REF_NUM TLV instance.
      *

--- a/jsmpp/src/main/java/org/jsmpp/util/HexUtil.java
+++ b/jsmpp/src/main/java/org/jsmpp/util/HexUtil.java
@@ -29,6 +29,10 @@ public class HexUtil {
     private static final char[] hexChar = { '0', '1', '2', '3', '4', '5', '6',
             '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
 
+    private HexUtil() {
+        throw new InstantiationError("This class must not be instantiated");
+    }
+
     /**
      * Convert the string to hex string value.
      * 

--- a/jsmpp/src/main/java/org/jsmpp/util/IntUtil.java
+++ b/jsmpp/src/main/java/org/jsmpp/util/IntUtil.java
@@ -24,6 +24,10 @@ package org.jsmpp.util;
  */
 public class IntUtil {
 
+    private IntUtil() {
+        throw new InstantiationError("This class must not be instantiated");
+    }
+
     public static String to4DigitString(final int value) {
         return toNDigitString(value, 4);
     }

--- a/jsmpp/src/main/java/org/jsmpp/util/OctetUtil.java
+++ b/jsmpp/src/main/java/org/jsmpp/util/OctetUtil.java
@@ -23,6 +23,11 @@ package org.jsmpp.util;
  * 
  */
 public class OctetUtil {
+
+    private OctetUtil() {
+        throw new InstantiationError("This class must not be instantiated");
+    }
+
     /**
      * Convert integer (4 octets) value to bytes.
      * 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructor.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1118
Please let me know if you have any questions.
George Kankava