### PR TITLE
Multiple code improvements: squid:S00105, squid:S1165

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/InvalidNumberOfDestinationsException.java
+++ b/jsmpp/src/main/java/org/jsmpp/InvalidNumberOfDestinationsException.java
@@ -10,7 +10,7 @@ package org.jsmpp;
  */
 public class InvalidNumberOfDestinationsException extends PDUException {
     private static final long serialVersionUID = -1515128166927438310L;
-    private int actualLength;
+    private final int actualLength;
     
     /**
      * Default constructor.

--- a/jsmpp/src/main/java/org/jsmpp/InvalidRequestException.java
+++ b/jsmpp/src/main/java/org/jsmpp/InvalidRequestException.java
@@ -23,41 +23,41 @@ package org.jsmpp;
  *
  */
 public class InvalidRequestException extends Exception {
-	private static final long serialVersionUID = -2275241874120654607L;
+    private static final long serialVersionUID = -2275241874120654607L;
 
-	/**
-	 * Default constructor.
-	 */
-	public InvalidRequestException() {
-		super();
-	}
+    /**
+     * Default constructor.
+     */
+    public InvalidRequestException() {
+        super();
+    }
 
-	/**
+    /**
      * Construct with specified message and cause.
      * 
-	 * @param message is the detail message.
-	 * @param cause is the parent cause.
-	 */
-	public InvalidRequestException(String message, Throwable cause) {
-		super(message, cause);
-	}
+     * @param message is the detail message.
+     * @param cause is the parent cause.
+     */
+    public InvalidRequestException(String message, Throwable cause) {
+        super(message, cause);
+    }
 
-	/**
+    /**
      * Construct with specified message.
      * 
-	 * @param message is the detail message.
-	 */
-	public InvalidRequestException(String message) {
-		super(message);
-	}
+     * @param message is the detail message.
+     */
+    public InvalidRequestException(String message) {
+        super(message);
+    }
 
-	/**
+    /**
      * Construct with specified cause.
      * 
-	 * @param cause is the parent cause.
-	 */
-	public InvalidRequestException(Throwable cause) {
-		super(cause);
-	}
-	
+     * @param cause is the parent cause.
+     */
+    public InvalidRequestException(Throwable cause) {
+        super(cause);
+    }
+    
 }

--- a/jsmpp/src/main/java/org/jsmpp/InvalidResponseException.java
+++ b/jsmpp/src/main/java/org/jsmpp/InvalidResponseException.java
@@ -29,19 +29,19 @@ public class InvalidResponseException extends Exception {
     /**
      * Construct with specified message and cause.
      * 
-	 * @param message is the detail message.
-	 * @param cause is the parent cause.
-	 */
-	public InvalidResponseException(String message, Throwable cause) {
-		super(message, cause);
-	}
+     * @param message is the detail message.
+     * @param cause is the parent cause.
+     */
+    public InvalidResponseException(String message, Throwable cause) {
+        super(message, cause);
+    }
 
-	/**
+    /**
      * Construct with specified message.
      * 
-	 * @param message is the detail message.
-	 */
-	public InvalidResponseException(String message) {
-		super(message);
-	}
+     * @param message is the detail message.
+     */
+    public InvalidResponseException(String message) {
+        super(message);
+    }
 }

--- a/jsmpp/src/main/java/org/jsmpp/MessageCoding.java
+++ b/jsmpp/src/main/java/org/jsmpp/MessageCoding.java
@@ -23,10 +23,10 @@ package org.jsmpp;
  *
  */
 public enum MessageCoding {
-	/**
-	 * Coding 7-bit.
-	 */
-	CODING_7_BIT,
+    /**
+     * Coding 7-bit.
+     */
+    CODING_7_BIT,
     
     /**
      * Coding 8-bit.

--- a/jsmpp/src/main/java/org/jsmpp/PDUException.java
+++ b/jsmpp/src/main/java/org/jsmpp/PDUException.java
@@ -24,40 +24,40 @@ package org.jsmpp;
  */
 public class PDUException extends Exception {
 
-	private static final long serialVersionUID = -4168434058788171394L;
+    private static final long serialVersionUID = -4168434058788171394L;
 
-	/**
-	 * Default constructor.
-	 */
-	public PDUException() {
-		super("PDUException found");
-	}
+    /**
+     * Default constructor.
+     */
+    public PDUException() {
+        super("PDUException found");
+    }
 
-	/**
+    /**
      * Construct with specified message and cause.
      * 
-	 * @param message is the detail message.
-	 * @param cause is the parent cause.
-	 */
-	public PDUException(String message, Throwable cause) {
-		super(message, cause);
-	}
+     * @param message is the detail message.
+     * @param cause is the parent cause.
+     */
+    public PDUException(String message, Throwable cause) {
+        super(message, cause);
+    }
 
-	/**
+    /**
      * Construct with specified message.
      * 
-	 * @param message is the detail message.
-	 */
-	public PDUException(String message) {
-		super(message);
-	}
+     * @param message is the detail message.
+     */
+    public PDUException(String message) {
+        super(message);
+    }
 
-	/**
+    /**
      * Construct with specified cause.
      * 
-	 * @param cause is the parent cause.
-	 */
-	public PDUException(Throwable cause) {
-		super(cause);
-	}
+     * @param cause is the parent cause.
+     */
+    public PDUException(Throwable cause) {
+        super(cause);
+    }
 }

--- a/jsmpp/src/main/java/org/jsmpp/PDUStringException.java
+++ b/jsmpp/src/main/java/org/jsmpp/PDUStringException.java
@@ -26,7 +26,7 @@ import org.jsmpp.util.StringParameter;
  */
 public class PDUStringException extends PDUException {
     private static final long serialVersionUID = 5456303478921567516L;
-    private StringParameter parameter;
+    private final StringParameter parameter;
 
     /**
      * Construct with specified message and parameter.


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rules
squid:S00105 - Tabulation characters should not be used.
squid:S1165 - Exception classes should be immutable.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S00105
https://dev.eclipse.org/sonar/rules/show/squid:S1165
Please let me know if you have any questions.
George Kankava