### PR TITLE
multiple code improvements: squid:S1213, squid:S1488, squid:S1197, squid:S00115

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/DefaultPDUSender.java
+++ b/jsmpp/src/main/java/org/jsmpp/DefaultPDUSender.java
@@ -110,7 +110,7 @@ public class DefaultPDUSender implements PDUSender {
             int sequenceNumber, String systemId, InterfaceVersion interfaceVersion) throws PDUStringException,
             IOException {
         
-        OptionalParameter p[];
+        OptionalParameter[] p;
         if(interfaceVersion != null) {
             OptionalParameter interfaceVersionParam = new OptionalParameter.Byte(Tag.SC_INTERFACE_VERSION, interfaceVersion.value());
             p = new OptionalParameter[] {interfaceVersionParam};

--- a/jsmpp/src/main/java/org/jsmpp/SMPPConstant.java
+++ b/jsmpp/src/main/java/org/jsmpp/SMPPConstant.java
@@ -343,7 +343,7 @@ public interface SMPPConstant {
 
     public static final short TAG_SC_INTERFACE_VERSION = 0x0210;
     public static final short TAG_SAR_MSG_REF_NUM = 0X020C;
-    public static final short TAG_SAR_TOTAl_SEGMENTS = 0x020e;
+    public static final short TAG_SAR_TOTAL_SEGMENTS = 0x020e;
     public static final short TAG_SAR_SEGMENT_SEQNUM = 0x020f;
 
     /*

--- a/jsmpp/src/main/java/org/jsmpp/bean/DeliverSm.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/DeliverSm.java
@@ -25,6 +25,10 @@ public class DeliverSm extends MessageRequest {
 
 	private String id;
 
+	public DeliverSm() {
+		super();
+	}
+
 	public String getId() {
 		return id;
 	}
@@ -33,10 +37,6 @@ public class DeliverSm extends MessageRequest {
 		this.id = id;
 	}
 
-	public DeliverSm() {
-		super();
-	}
-	
 	/**
      * Get the short message as {@link DeliveryReceipt}. This method will be
      * valid if the parsed short message valid and Message Type (esm_class)

--- a/jsmpp/src/main/java/org/jsmpp/bean/SarSegmentSeqnum.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/SarSegmentSeqnum.java
@@ -45,8 +45,7 @@ public class SarSegmentSeqnum {
 
     @Override
     public int hashCode() {
-        int result = 1;
-        return result;
+        return 1;
     }
 
     @Override

--- a/jsmpp/src/main/java/org/jsmpp/bean/SarTotalSegments.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/SarTotalSegments.java
@@ -32,7 +32,7 @@ public class SarTotalSegments {
     }
 
     public short getTag() {
-        return SMPPConstant.TAG_SAR_TOTAl_SEGMENTS;
+        return SMPPConstant.TAG_SAR_TOTAL_SEGMENTS;
     }
 
     public short getLength() {
@@ -45,8 +45,7 @@ public class SarTotalSegments {
 
     @Override
     public int hashCode() {
-        int result = 1;
-        return result;
+        return 1;
     }
 
     @Override


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
squid:S1488 -Local Variables should not be declared and then immediately returned or thrown.
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:S00115 - Constant names should comply with a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1213
https://dev.eclipse.org/sonar/rules/show/squid:S1488
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:S00115
Please let me know if you have any questions.
George Kankava