### PR TITLE
multiple code improvements: squid:S1197, squid:S1170

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/bean/DataCodingFactory1111.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/DataCodingFactory1111.java
@@ -33,7 +33,7 @@ public class DataCodingFactory1111 extends AbstractDataCodingFactory {
     /**
      * bin: 11110111
      */
-    private final byte MASK_BIT3_REMOVAL = (byte)0xf7;
+    private static final byte MASK_BIT3_REMOVAL = (byte)0xf7;
     
     public DataCodingFactory1111() {
         super(MASK, GROUP);

--- a/jsmpp/src/main/java/org/jsmpp/bean/OptionalParameter.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/OptionalParameter.java
@@ -1729,7 +1729,7 @@ public abstract class OptionalParameter {
 	 */
 	public static class Message_payload extends OptionalParameter.OctetString {
 
-		public Message_payload(byte value[]) {
+		public Message_payload(byte[] value) {
 			super(Tag.MESSAGE_PAYLOAD.code(), value);
 		}
 	}
@@ -1970,7 +1970,7 @@ public abstract class OptionalParameter {
 	 *
 	 */
 	public static class Billing_identification extends OptionalParameter.OctetString {
-		public Billing_identification(byte value[]) {
+		public Billing_identification(byte[] value) {
 			super(Tag.BILLING_IDENTIFICATION.code, value);
 		}
 
@@ -2138,7 +2138,7 @@ public abstract class OptionalParameter {
 	 */
 	public static class Vendor_specific_source_msc_addr extends OptionalParameter.Vendor_specific_msc_addr {
 		
-		public Vendor_specific_source_msc_addr(byte value[]) {
+		public Vendor_specific_source_msc_addr(byte[] value) {
 			super(Tag.VENDOR_SPECIFIC_SOURCE_MSC_ADDR.code, value);
 		}
 	}
@@ -2152,7 +2152,7 @@ public abstract class OptionalParameter {
 	 */
 	public static class Vendor_specific_dest_msc_addr extends OptionalParameter.Vendor_specific_msc_addr {
 		
-		public Vendor_specific_dest_msc_addr(byte value[]) {
+		public Vendor_specific_dest_msc_addr(byte[] value) {
 			super(Tag.VENDOR_SPECIFIC_DEST_MSC_ADDR.code, value);
 		}
 	}
@@ -2160,7 +2160,7 @@ public abstract class OptionalParameter {
 	private static class Vendor_specific_msc_addr extends OptionalParameter.OctetString {
 		String address;
 		
-		private Vendor_specific_msc_addr(short tag, byte value[]) {
+		private Vendor_specific_msc_addr(short tag, byte[] value) {
 			super(tag, value);
 			try {
         if (value.length >= 2) {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1197 - Array designators "[]" should be on the type, not the variable.
squid:S1170 - Public constants should be declared "static final" rather than merely "final".
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1197
https://dev.eclipse.org/sonar/rules/show/squid:S1170
Please let me know if you have any questions.
George Kankava