### PR TITLE
multiple code improvements: squid:S00117, squid:S1192, squid:S1213

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/session/QuerySmResult.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/QuerySmResult.java
@@ -61,10 +61,10 @@ public class QuerySmResult {
 	 */
 	@Override
 	public int hashCode() {
-		final int PRIME = 31;
+		final int prime = 31;
 		int result = 1;
-		result = PRIME * result + ((finalDate == null) ? 0 : finalDate.hashCode());
-		result = PRIME * result + ((messageState == null) ? 0 : messageState.hashCode());
+		result = prime * result + ((finalDate == null) ? 0 : finalDate.hashCode());
+		result = prime * result + ((messageState == null) ? 0 : messageState.hashCode());
 		return result;
 	}
 	

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPServerSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPServerSession.java
@@ -66,6 +66,9 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class SMPPServerSession extends AbstractSession implements ServerSession {
+    private static final String MESSAGE_RECEIVER_LISTENER_IS_NULL = "Received SubmitMultiSm but MessageReceiverListener is null, returning SMPP error";
+    private static final String NO_MESSAGE_RECEIVER_LISTENER_REGISTERED = "No message receiver listener registered";
+
     private static final Logger logger = LoggerFactory.getLogger(SMPPServerSession.class);
     
     private final Connection conn;
@@ -191,7 +194,7 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
             return messageReceiverListener.onAcceptSubmitSm(submitSm, this);
         }
         logger.warn("Received SubmitSm but MessageReceiverListener is null, returning SMPP error");
-        throw new ProcessRequestException("No message receiver listener registered",
+        throw new ProcessRequestException(NO_MESSAGE_RECEIVER_LISTENER_REGISTERED,
                 SMPPConstant.STAT_ESME_RX_R_APPN);
     }
     
@@ -199,8 +202,8 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
         if (messageReceiverListener != null) {
             return messageReceiverListener.onAcceptSubmitMulti(submitMulti, this);
         }
-        logger.warn("Received SubmitMultiSm but MessageReceiverListener is null, returning SMPP error");
-        throw new ProcessRequestException("No message receiver listener registered",
+        logger.warn(MESSAGE_RECEIVER_LISTENER_IS_NULL);
+        throw new ProcessRequestException(NO_MESSAGE_RECEIVER_LISTENER_REGISTERED,
                 SMPPConstant.STAT_ESME_RX_R_APPN);
     }
     
@@ -209,7 +212,7 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
             return messageReceiverListener.onAcceptQuerySm(querySm, this);
         }
         logger.warn("Received SubmitQuerySm but MessageReceiverListener is null, returning SMPP error");
-        throw new ProcessRequestException("No message receiver listener registered", 
+        throw new ProcessRequestException(NO_MESSAGE_RECEIVER_LISTENER_REGISTERED, 
                 SMPPConstant.STAT_ESME_RX_R_APPN);
     }
     
@@ -217,8 +220,8 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
         if (messageReceiverListener != null) {
             messageReceiverListener.onAcceptReplaceSm(replaceSm, this);
         } else {
-            logger.warn("Received SubmitMultiSm but MessageReceiverListener is null, returning SMPP error");
-            throw new ProcessRequestException("No message receiver listener registered",
+            logger.warn(MESSAGE_RECEIVER_LISTENER_IS_NULL);
+            throw new ProcessRequestException(NO_MESSAGE_RECEIVER_LISTENER_REGISTERED,
                     SMPPConstant.STAT_ESME_RX_R_APPN);
         }
     }
@@ -227,8 +230,8 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
         if (messageReceiverListener != null) {
             messageReceiverListener.onAcceptCancelSm(cancelSm, this);
         } else {
-            logger.warn("Received SubmitMultiSm but MessageReceiverListener is null, returning SMPP error");
-            throw new ProcessRequestException("No message receiver listener registered",
+            logger.warn(MESSAGE_RECEIVER_LISTENER_IS_NULL);
+            throw new ProcessRequestException(NO_MESSAGE_RECEIVER_LISTENER_REGISTERED,
                     SMPPConstant.STAT_ESME_RX_R_APPN);
         }
     }

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
@@ -294,9 +294,9 @@ public class SMPPSession extends AbstractSession implements ClientSession {
                 addrNpi, addressRange);
 	    
 	    BindResp resp = (BindResp)executeSendCommand(task, timeout);
-	    OptionalParameter.Sc_interface_version sc_version = resp.getOptionalParameter(Sc_interface_version.class);
-	    if(sc_version != null) {
-		    logger.info("Other side reports smpp interface version {}", sc_version);
+	    OptionalParameter.Sc_interface_version scVersion = resp.getOptionalParameter(Sc_interface_version.class);
+	    if(scVersion != null) {
+		    logger.info("Other side reports smpp interface version {}", scVersion);
 	    }
         
 		return resp.getSystemId();
@@ -564,16 +564,15 @@ public class SMPPSession extends AbstractSession implements ClientSession {
 	private class PDUReaderWorker extends Thread {
 		// start with serial execution of pdu processing, when the session is bound the pool will be enlarge up to the PduProcessorDegree
 	    private ExecutorService executorService = Executors.newFixedThreadPool(1); 
-		
-	    public PDUReaderWorker() {
-        	super("PDUReaderWorker: " + SMPPSession.this);
-	    }
-	    
 	    private Runnable onIOExceptionTask = new Runnable() {
 		    public void run() {
 		        close();
 		    };
 		};
+		
+	    public PDUReaderWorker() {
+        	super("PDUReaderWorker: " + SMPPSession.this);
+	    }
 		
 	    @Override
 		public void run() {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S00117 Local variable and method parameter names should comply with a naming convention,
squid:S1192 String literals should not be duplicated,
squid:S1213 The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS00117
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1192
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1213
Please let me know if you have any questions.
George Kankava