### PR TITLE
multiple code improvements: squid:S1213, squid:S1905, squid:S1488, squid:S2325, pmd:ImmutableField

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/session/connection/socket/SocketConnectionFactory.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/connection/socket/SocketConnectionFactory.java
@@ -27,11 +27,11 @@ import org.jsmpp.session.connection.ConnectionFactory;
 public class SocketConnectionFactory implements ConnectionFactory {
     private static final SocketConnectionFactory connFactory = new SocketConnectionFactory();
     
-    public static SocketConnectionFactory getInstance() {
-        return connFactory;
+    private SocketConnectionFactory() {
     }
     
-    private SocketConnectionFactory() {
+    public static SocketConnectionFactory getInstance() {
+        return connFactory;
     }
     
     public Connection createConnection(String host, int port)

--- a/jsmpp/src/main/java/org/jsmpp/util/AbsoluteTimeFormatter.java
+++ b/jsmpp/src/main/java/org/jsmpp/util/AbsoluteTimeFormatter.java
@@ -57,7 +57,7 @@ public class AbsoluteTimeFormatter implements TimeFormatter {
         }
         
         // Time difference in quarter hours
-        int timeDiff = (int)(Math.abs(offset) / (15 * 60 * 1000));
+        int timeDiff = Math.abs(offset) / (15 * 60 * 1000);
         
         return format(year, month, day, hour, minute, second, tenthsOfSecond, timeDiff, sign);
     }

--- a/jsmpp/src/main/java/org/jsmpp/util/DefaultComposer.java
+++ b/jsmpp/src/main/java/org/jsmpp/util/DefaultComposer.java
@@ -437,9 +437,8 @@ public class DefaultComposer implements PDUComposer {
     }
 
     public byte[] cancelSmResp(int sequenceNumber) {
-        byte[] b = composeHeader(SMPPConstant.CID_CANCEL_SM_RESP,
+        return composeHeader(SMPPConstant.CID_CANCEL_SM_RESP,
                 SMPPConstant.STAT_ESME_ROK, sequenceNumber);
-        return b;
     }
 
     public byte[] replaceSm(int sequenceNumber, String messageId,

--- a/jsmpp/src/main/java/org/jsmpp/util/DefaultDecomposer.java
+++ b/jsmpp/src/main/java/org/jsmpp/util/DefaultDecomposer.java
@@ -614,7 +614,7 @@ public class DefaultDecomposer implements PDUDecomposer {
         return req;
     }
     
-    private OptionalParameter[] readOptionalParameters(
+    private static OptionalParameter[] readOptionalParameters(
             SequentialBytesReader reader) {
         if (!reader.hasMoreBytes())
             return null;

--- a/jsmpp/src/main/java/org/jsmpp/util/PDUByteBuffer.java
+++ b/jsmpp/src/main/java/org/jsmpp/util/PDUByteBuffer.java
@@ -27,7 +27,7 @@ import org.jsmpp.bean.OptionalParameter;
  * 
  */
 public class PDUByteBuffer {
-    private static CapacityPolicy DEFAULT_CAPACITY_POLICY = new SimpleCapacityPolicy();
+    private static final CapacityPolicy DEFAULT_CAPACITY_POLICY = new SimpleCapacityPolicy();
     private CapacityPolicy capacityPolicy;
     private byte[] bytes;
     private int bytesLength;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1213 The members of an interface declaration or class should appear in a pre-defined order,
squid:S1905 Redundant casts should not be used,
squid:S1488 Local Variables should not be declared and then immediately returned or thrown,
squid:S2325 private methods that don't access instance data should be static,
pmd:ImmutableField Immutable Field.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1213
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1905
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1488
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS2325
https://dev.eclipse.org/sonar/coding_rules#q=pmd%3AImmutableField
Please let me know if you have any questions.
George Kankava