### PR TITLE
squid:S1192 String literals should not be duplicated

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/session/state/SMPPServerSessionClosed.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/state/SMPPServerSessionClosed.java
@@ -27,82 +27,84 @@ import org.jsmpp.session.ServerResponseHandler;
  */
 class SMPPServerSessionClosed implements SMPPServerSessionState {
 
+    private static final String INVALID_PROCESS_FOR_CLOSED_SESSION = "Invalid process for closed session state";
+
     public SessionState getSessionState() {
         return SessionState.CLOSED;
     }
     
     public void processBind(Command pduHeader, byte[] pdu,
             ServerResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
 
     public void processDeliverSmResp(Command pduHeader, byte[] pdu,
             ServerResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
 
     public void processQuerySm(Command pduHeader, byte[] pdu,
             ServerResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
 
     public void processSubmitSm(Command pduHeader, byte[] pdu,
             ServerResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
     
     public void processSubmitMulti(Command pduHeader, byte[] pdu,
             ServerResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
     
     public void processEnquireLink(Command pduHeader, byte[] pdu,
             BaseResponseHandler sessionHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
 
     public void processEnquireLinkResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler sessionHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
 
     public void processGenericNack(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
 
     public void processUnbind(Command pduHeader, byte[] pdu,
             BaseResponseHandler sessionHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
 
     public void processUnbindResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler sessionHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
 
     public void processUnknownCid(Command pduHeader, byte[] pdu,
             BaseResponseHandler sessionHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
     
     public void processDataSm(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
     
     public void processDataSmResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
     
     public void processCancelSm(Command pduHeader, byte[] pdu,
             ServerResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
     
     public void processReplaceSm(Command pduHeader, byte[] pdu,
             ServerResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
 }

--- a/jsmpp/src/main/java/org/jsmpp/session/state/SMPPServerSessionOpen.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/state/SMPPServerSessionOpen.java
@@ -31,6 +31,7 @@ import org.jsmpp.util.PDUDecomposer;
  *
  */
 class SMPPServerSessionOpen implements SMPPServerSessionState {
+    private static final String INVALID_PROCESS_FOR_OPEN_SESSION = "Invalid process for open session state";
     private static final PDUDecomposer pduDecomposer = new DefaultDecomposer();
     
     public SessionState getSessionState() {
@@ -53,73 +54,73 @@ class SMPPServerSessionOpen implements SMPPServerSessionState {
 
     public void processDeliverSmResp(Command pduHeader, byte[] pdu,
             ServerResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for open session state");
+        throw new IOException(INVALID_PROCESS_FOR_OPEN_SESSION);
     }
 
     public void processQuerySm(Command pduHeader, byte[] pdu,
             ServerResponseHandler responseHandler)
             throws IOException {
-        throw new IOException("Invalid process for open session state");
+        throw new IOException(INVALID_PROCESS_FOR_OPEN_SESSION);
     }
 
     public void processSubmitSm(Command pduHeader, byte[] pdu,
             ServerResponseHandler responseHandler)
             throws IOException {
-        throw new IOException("Invalid process for open session state");
+        throw new IOException(INVALID_PROCESS_FOR_OPEN_SESSION);
     }
     
     public void processSubmitMulti(Command pduHeader, byte[] pdu,
             ServerResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for open session state");
+        throw new IOException(INVALID_PROCESS_FOR_OPEN_SESSION);
     }
 
     public void processEnquireLink(Command pduHeader, byte[] pdu,
             BaseResponseHandler sessionHandler) throws IOException {
-        throw new IOException("Invalid process for open session state");
+        throw new IOException(INVALID_PROCESS_FOR_OPEN_SESSION);
     }
 
     public void processEnquireLinkResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler sessionHandler) throws IOException {
-        throw new IOException("Invalid process for open session state");
+        throw new IOException(INVALID_PROCESS_FOR_OPEN_SESSION);
     }
 
     public void processGenericNack(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for open session state");
+        throw new IOException(INVALID_PROCESS_FOR_OPEN_SESSION);
     }
 
     public void processUnbind(Command pduHeader, byte[] pdu,
             BaseResponseHandler sessionHandler) throws IOException {
-        throw new IOException("Invalid process for open session state");
+        throw new IOException(INVALID_PROCESS_FOR_OPEN_SESSION);
     }
 
     public void processUnbindResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler sessionHandler) throws IOException {
-        throw new IOException("Invalid process for open session state");
+        throw new IOException(INVALID_PROCESS_FOR_OPEN_SESSION);
     }
 
     public void processUnknownCid(Command pduHeader, byte[] pdu,
             BaseResponseHandler sessionHandler) throws IOException {
-        throw new IOException("Invalid process for open session state");
+        throw new IOException(INVALID_PROCESS_FOR_OPEN_SESSION);
     }
     
     public void processDataSm(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for open session state");
+        throw new IOException(INVALID_PROCESS_FOR_OPEN_SESSION);
     }
     
     public void processDataSmResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for open session state");
+        throw new IOException(INVALID_PROCESS_FOR_OPEN_SESSION);
     }
     
     public void processCancelSm(Command pduHeader, byte[] pdu,
             ServerResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for open session state");
+        throw new IOException(INVALID_PROCESS_FOR_OPEN_SESSION);
     }
     
     public void processReplaceSm(Command pduHeader, byte[] pdu,
             ServerResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for open session state");
+        throw new IOException(INVALID_PROCESS_FOR_OPEN_SESSION);
     }
 }

--- a/jsmpp/src/main/java/org/jsmpp/session/state/SMPPServerSessionUnbound.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/state/SMPPServerSessionUnbound.java
@@ -27,6 +27,8 @@ import org.jsmpp.session.ServerResponseHandler;
  */
 public class SMPPServerSessionUnbound implements SMPPServerSessionState {
     
+    private static final String INVALID_PROCESS_FOR_UNBOUND_SESSION = "Invalid process for unbound session state";
+
     public SessionState getSessionState() {
         return SessionState.UNBOUND;
     }
@@ -34,78 +36,78 @@ public class SMPPServerSessionUnbound implements SMPPServerSessionState {
     public void processBind(Command pduHeader, byte[] pdu,
             ServerResponseHandler responseHandler)
             throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
 
     public void processDeliverSmResp(Command pduHeader, byte[] pdu,
             ServerResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
 
     public void processQuerySm(Command pduHeader, byte[] pdu,
             ServerResponseHandler responseHandler)
             throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
 
     public void processSubmitSm(Command pduHeader, byte[] pdu,
             ServerResponseHandler responseHandler)
             throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
     
     public void processSubmitMulti(Command pduHeader, byte[] pdu,
             ServerResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
     
     public void processEnquireLink(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
 
     public void processEnquireLinkResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
 
     public void processGenericNack(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
 
     public void processUnbind(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
 
     public void processUnbindResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
 
     public void processUnknownCid(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
     
     public void processDataSm(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
     
     public void processDataSmResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
     
     public void processCancelSm(Command pduHeader, byte[] pdu,
             ServerResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
     
     public void processReplaceSm(Command pduHeader, byte[] pdu,
             ServerResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
 }

--- a/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionBoundTX.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionBoundTX.java
@@ -41,6 +41,7 @@ import org.slf4j.LoggerFactory;
  * 
  */
 class SMPPSessionBoundTX extends SMPPSessionBound implements SMPPSessionState {
+    private static final String NO_REQUEST_FIND_FOR_SEQUENCE_NUMBER = "No request find for sequence number ";
     private static final Logger logger = LoggerFactory.getLogger(SMPPSessionBoundTX.class);
     
     public SessionState getSessionState() {
@@ -101,7 +102,7 @@ class SMPPSessionBoundTX extends SMPPSessionBound implements SMPPSessionState {
                         .getSequenceNumber());
             }
         } else {
-            logger.error("No request find for sequence number "
+            logger.error(NO_REQUEST_FIND_FOR_SEQUENCE_NUMBER
                     + pduHeader.getSequenceNumber());
             responseHandler.sendGenerickNack(
                     SMPPConstant.STAT_ESME_RINVDFTMSGID, pduHeader
@@ -117,7 +118,7 @@ class SMPPSessionBoundTX extends SMPPSessionBound implements SMPPSessionState {
             CancelSmResp resp = pduDecomposer.cancelSmResp(pdu);
             pendingResp.done(resp);
         } else {
-            logger.error("No request find for sequence number "
+            logger.error(NO_REQUEST_FIND_FOR_SEQUENCE_NUMBER
                     + pduHeader.getSequenceNumber());
         }
     }
@@ -130,7 +131,7 @@ class SMPPSessionBoundTX extends SMPPSessionBound implements SMPPSessionState {
             ReplaceSmResp resp = pduDecomposer.replaceSmResp(pdu);
             pendingResp.done(resp);
         } else {
-            logger.error("No request find for sequence number "
+            logger.error(NO_REQUEST_FIND_FOR_SEQUENCE_NUMBER
                     + pduHeader.getSequenceNumber());
         }
     }

--- a/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionClosed.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionClosed.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
  * 
  */
 class SMPPSessionClosed implements SMPPSessionState {
+    private static final String INVALID_PROCESS_FOR_CLOSED_SESSION = "Invalid process for closed session state";
     private static final Logger logger = LoggerFactory.getLogger(SMPPSessionClosed.class);
     
     public SessionState getSessionState() {
@@ -42,77 +43,77 @@ class SMPPSessionClosed implements SMPPSessionState {
     
     public void processBindResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
 
     public void processDeliverSm(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
 
     public void processEnquireLink(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
 
     public void processEnquireLinkResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
 
     public void processGenericNack(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
 
     public void processQuerySmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
 
     public void processSubmitSmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
     
     public void processSubmitMultiResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
     
     public void processUnbind(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
 
     public void processUnbindResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
 
     public void processUnknownCid(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
     
     public void processDataSm(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
     
     public void processDataSmResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
     
     public void processCancelSmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
     
     public void processReplaceSmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for closed session state");
+        throw new IOException(INVALID_PROCESS_FOR_CLOSED_SESSION);
     }
     
     public void processAlertNotification(Command pduHeader, byte[] pdu,

--- a/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionUnbound.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionUnbound.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
  * 
  */
 class SMPPSessionUnbound implements SMPPSessionState {
+    private static final String INVALID_PROCESS_FOR_UNBOUND_SESSION = "Invalid process for unbound session state";
     private static final Logger logger = LoggerFactory.getLogger(SMPPSessionUnbound.class);
     
     public SessionState getSessionState() {
@@ -42,77 +43,77 @@ class SMPPSessionUnbound implements SMPPSessionState {
     
     public void processBindResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
 
     public void processDeliverSm(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
 
     public void processEnquireLink(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
 
     public void processEnquireLinkResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
 
     public void processGenericNack(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
 
     public void processSubmitSmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
     
     public void processSubmitMultiResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
     
     public void processUnbind(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
 
     public void processUnbindResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
 
     public void processUnknownCid(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
 
     public void processQuerySmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
     
     public void processDataSm(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
     
     public void processDataSmResp(Command pduHeader, byte[] pdu,
             BaseResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
     
     public void processCancelSmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
     
     public void processReplaceSmResp(Command pduHeader, byte[] pdu,
             ResponseHandler responseHandler) throws IOException {
-        throw new IOException("Invalid process for unbound session state");
+        throw new IOException(INVALID_PROCESS_FOR_UNBOUND_SESSION);
     }
     
     public void processAlertNotification(Command pduHeader, byte[] pdu,


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S1192 String literals should not be duplicated.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1192
Please let me know if you have any questions.
George Kankava