### PR TITLE
multiple code improvements: squid:S1192, squid:AssignmentInSubExpressionCheck, squid:S1149, squid:S1165

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/extra/NegativeResponseException.java
+++ b/jsmpp/src/main/java/org/jsmpp/extra/NegativeResponseException.java
@@ -12,7 +12,7 @@ import org.jsmpp.util.IntUtil;
  */
 public class NegativeResponseException extends Exception {
     private static final long serialVersionUID = 7198456791204091251L;
-    private int commandStatus;
+    private final int commandStatus;
 
     /**
      * Construct with specified command_status.

--- a/jsmpp/src/main/java/org/jsmpp/util/HexUtil.java
+++ b/jsmpp/src/main/java/org/jsmpp/util/HexUtil.java
@@ -83,12 +83,12 @@ public class HexUtil {
      */
     public static String convertHexStringToString(String hexString) {
         String uHexString = hexString.toLowerCase();
-        StringBuffer sBuf = new StringBuffer();
+        StringBuilder sBld = new StringBuilder();
         for (int i = 0; i < uHexString.length(); i = i + 2) {
             char c = (char)Integer.parseInt(uHexString.substring(i, i + 2), 16);
-            sBuf.append(c);
+            sBld.append(c);
         }
-        return sBuf.toString();
+        return sBld.toString();
     }
 
     /**

--- a/jsmpp/src/main/java/org/jsmpp/util/StopWatch.java
+++ b/jsmpp/src/main/java/org/jsmpp/util/StopWatch.java
@@ -29,7 +29,8 @@ public class StopWatch {
      * @return the current time in millisecond.
      */
     public long start() {
-        return startTime = System.currentTimeMillis();
+        startTime = System.currentTimeMillis();
+        return startTime;
     }
     
     /**

--- a/jsmpp/src/main/java/org/jsmpp/util/StringValidator.java
+++ b/jsmpp/src/main/java/org/jsmpp/util/StringValidator.java
@@ -25,6 +25,9 @@ import org.jsmpp.PDUStringException;
  * 
  */
 public final class StringValidator {
+    private static final String ACTUAL_LENGTH_IS = ". Actual length is ";
+    private static final String C_OCTET_STRING_VALUE = "C-Octet String value '";
+
     private StringValidator() {
     }
 
@@ -33,22 +36,22 @@ public final class StringValidator {
         if (param.getType() == StringType.C_OCTET_STRING) {
             if (param.isRangeMinAndMax()) {
                 if (!isCOctetStringValid(value, param.getMax())) {
-                    throw new PDUStringException("C-Octet String value '"
+                    throw new PDUStringException(C_OCTET_STRING_VALUE
                             + value + "' length must be less than " + param.getMax()
-                            + ". Actual length is " + value.length(),
+                            + ACTUAL_LENGTH_IS + value.length(),
                             param);
                 }
             } else if (!isCOctetStringNullOrNValValid(value, param.getMax())) {
                 throw new PDUStringException(
-                        "C-Octet String value '" + value + "' length should be 1 or " + (param.getMax() - 1)
-                                + ". Actual length is "
+                        C_OCTET_STRING_VALUE + value + "' length should be 1 or " + (param.getMax() - 1)
+                                + ACTUAL_LENGTH_IS
                                 + value.length(), param);
             }
         } else if (param.getType() == StringType.OCTET_STRING
                 && !isOctetStringValid(value, param.getMax())) {
             throw new PDUStringException("Octet String value '" + value
                     + "' length must be less than or equal to " + param.getMax()
-                    + ". Actual length is " + value.length(), param);
+                    + ACTUAL_LENGTH_IS + value.length(), param);
         }
     }
 
@@ -57,22 +60,22 @@ public final class StringValidator {
         if (param.getType() == StringType.C_OCTET_STRING) {
             if (param.isRangeMinAndMax()) {
                 if (!isCOctetStringValid(value, param.getMax())) {
-                    throw new PDUStringException("C-Octet String value '"
+                    throw new PDUStringException(C_OCTET_STRING_VALUE
                             + new String(value) + "' length must be less than "
-                            + param.getMax() + ". Actual length is "
+                            + param.getMax() + ACTUAL_LENGTH_IS
                             + value.length, param);
                 }
             } else if (!isCOctetStringNullOrNValValid(value, param.getMax())) {
                 throw new PDUStringException(
-                        "C-Octet String value '" + new String(value) + "' length should be 1 or " + (param.getMax() - 1)
-                                + ". Actual length is "
+                        C_OCTET_STRING_VALUE + new String(value) + "' length should be 1 or " + (param.getMax() - 1)
+                                + ACTUAL_LENGTH_IS
                                 + value.length, param);
             }
         } else if (param.getType() == StringType.OCTET_STRING
                 && !isOctetStringValid(value, param.getMax())) {
             throw new PDUStringException("Octet String value '"
                     + new String(value) + "' length must be less than or equal to "
-                    + param.getMax() + ". Actual length is "
+                    + param.getMax() + ACTUAL_LENGTH_IS
                     + value.length, param);
         }
     }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1192 String literals should not be duplicated,
squid:AssignmentInSubExpressionCheck Assignments should not be made from within sub-expressions,
squid:S1149 Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used,
squid:S1165 Exception classes should be immutable.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1192
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AAssignmentInSubExpressionCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1149
https://dev.eclipse.org/sonar/coding_rules#q=squid%3AS1165
Please let me know if you have any questions.
George Kankava