### PR TITLE
squid:S1132 - Strings literals should be placed on the left side when checking for equality

### DIFF
--- a/jsmpp-examples/src/main/java/org/jsmpp/examples/AcceptingConnectionAndBindExample.java
+++ b/jsmpp-examples/src/main/java/org/jsmpp/examples/AcceptingConnectionAndBindExample.java
@@ -44,8 +44,8 @@ public class AcceptingConnectionAndBindExample {
                 BindRequest request = session.waitForBind(5000);
                 System.out.println("Receive bind request");
                 
-                if (request.getSystemId().equals("test") && 
-                        request.getPassword().equals("test")) {
+                if ("test".equals(request.getSystemId()) &&
+                        "test".equals(request.getPassword())) {
                     
                     // accepting request and send bind response immediately
                     System.out.println("Accepting bind request, interface version is " + request.getInterfaceVersion());

--- a/jsmpp-examples/src/main/java/org/jsmpp/examples/ReceiveSubmittedMessageExample.java
+++ b/jsmpp-examples/src/main/java/org/jsmpp/examples/ReceiveSubmittedMessageExample.java
@@ -105,8 +105,8 @@ public class ReceiveSubmittedMessageExample {
                 BindRequest request = session.waitForBind(5000);
                 System.out.println("Receive bind request");
                 
-                if (request.getSystemId().equals("test") && 
-                        request.getPassword().equals("test")) {
+                if ("test".equals(request.getSystemId()) &&
+                        "test".equals(request.getPassword())) {
                     
                     // accepting request and send bind response immediately
                     System.out.println("Accepting bind request");

--- a/jsmpp/src/main/java/org/jsmpp/session/AbstractSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/AbstractSession.java
@@ -273,7 +273,7 @@ public abstract class AbstractSession implements Session {
         } catch (IOException e) {
             logger.error("Failed sending " + task.getCommandName() + " command", e);
 
-            if(task.getCommandName().equals("enquire_link")) {
+            if("enquire_link".equals(task.getCommandName())) {
                 logger.info("Tomas: Ignore failure of sending enquire_link, wait to see if connection is restored");
             } else {
                 pendingResponse.remove(seqNum);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1132 - Strings literals should be placed on the left side when checking for equality.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1132
Please let me know if you have any questions.
George Kankava