### PR TITLE
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/session/AbstractSMPPOperation.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/AbstractSMPPOperation.java
@@ -15,7 +15,9 @@
 package org.jsmpp.session;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Hashtable;
+import java.util.Map;
 
 import org.jsmpp.InvalidResponseException;
 import org.jsmpp.PDUException;
@@ -45,7 +47,7 @@ import org.slf4j.LoggerFactory;
 public abstract class AbstractSMPPOperation implements SMPPOperation {
     private static final Logger logger = LoggerFactory.getLogger(AbstractSMPPOperation.class);
 
-    private final Hashtable<Integer, PendingResponse<Command>> pendingResponse = new Hashtable<Integer, PendingResponse<Command>>();
+    private final Map<Integer, PendingResponse<Command>> pendingResponse = new HashMap<Integer, PendingResponse<Command>>();
     private final Sequence sequence = new Sequence(1);
     private final PDUSender pduSender;
     private final Connection connection;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1149
Please let me know if you have any questions.
George Kankava