### PR TITLE
squid:S1161 - '@Override' annotation should be used on any method overriding (since Java 5) or implementing (since Java 6) another one

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/bean/DeliveryReceipt.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/DeliveryReceipt.java
@@ -217,6 +217,7 @@ public class DeliveryReceipt {
         }
     }
 
+    @Override
     public String toString() {
         /*
          * id:IIIIIIIIII sub:SSS dlvrd:DDD submit date:YYMMDDhhmm done

--- a/jsmpp/src/main/java/org/jsmpp/bean/OptionalParameter.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/OptionalParameter.java
@@ -119,6 +119,7 @@ public abstract class OptionalParameter {
         /**
          * Print Optional Parameter byte in hex format
          */
+        @Override
         public String toString()
         {
             return HexUtil.conventBytesToHexString(OctetUtil.shortToBytes(value));
@@ -157,6 +158,7 @@ public abstract class OptionalParameter {
         /**
          * Print Optional Parameter byte in hex format
          */
+        @Override
         public String toString()
         {
             return HexUtil.conventBytesToHexString(OctetUtil.intToBytes(value));
@@ -195,6 +197,7 @@ public abstract class OptionalParameter {
         /**
          * Print Optional Parameter byte in hex format
          */
+        @Override
         public String toString()
         {
             return HexUtil.conventBytesToHexString(new byte[] {getValue()});
@@ -238,7 +241,7 @@ public abstract class OptionalParameter {
         public byte[] getValue() {
             return value;
         }
-        
+
         public String getValueAsString() {
             return new String(value);
         }
@@ -363,6 +366,7 @@ public abstract class OptionalParameter {
 			return Addr_subunit.toEnum(value);
 		}
 
+		@Override
 		public String toString() {
 			return getDestAddrSubunit().toString();
 		}
@@ -388,7 +392,7 @@ public abstract class OptionalParameter {
 		private Network_type(int value) {
 			this.value = (byte)value;
 		}
-		
+
 		public byte value() {
 			return value;
 		}
@@ -434,6 +438,7 @@ public abstract class OptionalParameter {
 			return Network_type.toEnum(value);
 		}
 
+		@Override
 		public String toString() {
 			return getDestNetworkType().toString();
 		}
@@ -505,6 +510,7 @@ public abstract class OptionalParameter {
 			return Bearer_type.toEnum(value);
 		}
 
+		@Override
 		public String toString() {
 			return getDestBearerType().toString();
 		}
@@ -563,6 +569,7 @@ public abstract class OptionalParameter {
 			return Addr_subunit.toEnum(value);
 		}
 
+		@Override
 		public String toString() {
 			return getSourceAddrSubunit().toString();
 		}
@@ -598,6 +605,7 @@ public abstract class OptionalParameter {
 			return Network_type.toEnum(value);
 		}
 
+		@Override
 		public String toString() {
 			return getSourceNetworkType().toString();
 		}
@@ -632,7 +640,8 @@ public abstract class OptionalParameter {
 		public Bearer_type getSourceBearerType() {
 			return Bearer_type.toEnum(value);
 		}
-		
+
+		@Override
 		public String toString() {
 			return getSourceBearerType().toString();
 		}
@@ -749,7 +758,8 @@ public abstract class OptionalParameter {
 		public Payload_type_enum getPayloadType() {
 			return Payload_type_enum.toEnum(value);
 		}
-		
+
+		@Override
 		public String toString() {
 			return getPayloadType().toString();
 		}
@@ -860,7 +870,8 @@ public abstract class OptionalParameter {
 		public Ms_msg_wait_facilities_type getMessageType() {
 			return Ms_msg_wait_facilities_type.toEnum((byte)(value & 0x03));
 		}
-		
+
+		@Override
 		public String toString() {
 			String endString = isIndicatorActive() ? "active" : "inactive";
 			return getMessageType().toString() + " set as " + endString;
@@ -1930,7 +1941,8 @@ public abstract class OptionalParameter {
 		public Message_state_enum getMessageState() {
 			return Message_state_enum.toEnum(value);
 		}
-		
+
+		@Override
 		public String toString() {
 			return getMessageState().toString();
 		}

--- a/jsmpp/src/main/java/org/jsmpp/session/PDUProcessServerTask.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/PDUProcessServerTask.java
@@ -49,6 +49,7 @@ public class PDUProcessServerTask implements Runnable {
         this.onIOExceptionTask = onIOExceptionTask;
     }
 
+    @Override
     public void run() {
         try {
             if(logger.isDebugEnabled())

--- a/jsmpp/src/main/java/org/jsmpp/session/PDUProcessTask.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/PDUProcessTask.java
@@ -47,6 +47,7 @@ public class PDUProcessTask implements Runnable {
         this.onIOExceptionTask = onIOExceptionTask;
     }
 
+    @Override
     public void run() {
         try {
             if(logger.isDebugEnabled()) {

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPServerSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPServerSession.java
@@ -500,6 +500,7 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
     private class PDUReaderWorker extends Thread {
         private ExecutorService executorService = Executors.newFixedThreadPool(getPduProcessorDegree());
         private Runnable onIOExceptionTask = new Runnable() {
+            @Override
             public void run() {
                 close();
             };

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
@@ -565,6 +565,7 @@ public class SMPPSession extends AbstractSession implements ClientSession {
 		// start with serial execution of pdu processing, when the session is bound the pool will be enlarge up to the PduProcessorDegree
 	    private ExecutorService executorService = Executors.newFixedThreadPool(1); 
 	    private Runnable onIOExceptionTask = new Runnable() {
+		    @Override
 		    public void run() {
 		        close();
 		    };


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1161 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1161
Please let me know if you have any questions.
George Kankava