### PR TITLE
squid:S1168 - Empty arrays and collections should be returned instead of null

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/util/DefaultDecomposer.java
+++ b/jsmpp/src/main/java/org/jsmpp/util/DefaultDecomposer.java
@@ -617,7 +617,7 @@ public class DefaultDecomposer implements PDUDecomposer {
     private static OptionalParameter[] readOptionalParameters(
             SequentialBytesReader reader) {
         if (!reader.hasMoreBytes())
-            return null;
+            return new OptionalParameter[] {};
         List<OptionalParameter> params = new ArrayList<OptionalParameter>();
         while (reader.hasMoreBytes()) {
             short tag = reader.readShort();

--- a/jsmpp/src/main/java/org/jsmpp/util/SequentialBytesReader.java
+++ b/jsmpp/src/main/java/org/jsmpp/util/SequentialBytesReader.java
@@ -47,7 +47,7 @@ class SequentialBytesReader {
         int length = i - 1 - cursor;
         if (length == 0) {
             cursor += 1 + length;
-            return null;
+            return new byte[] {};
         }
         byte[] data = new byte[length];
         System.arraycopy(bytes, cursor, data, 0, length);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1168 - Empty arrays and collections should be returned instead of null.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1168
Please let me know if you have any questions.
George Kankava