### PR TITLE
squid:S2142 -'InterruptedException' should not be ignored

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/extra/PendingResponse.java
+++ b/jsmpp/src/main/java/org/jsmpp/extra/PendingResponse.java
@@ -106,6 +106,7 @@ public class PendingResponse<T extends Command> {
                 try {
                     condition.await(timeout, TimeUnit.MILLISECONDS);
                 } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
                 }
             }
             

--- a/jsmpp/src/main/java/org/jsmpp/session/AbstractSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/AbstractSession.java
@@ -218,6 +218,7 @@ public abstract class AbstractSession implements Session {
                     try {
                         enquireLinkSender.join();
                     } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
                         logger.warn("Interrupted while waiting for enquireLinkSender thread to exit");
                     }
                 }
@@ -423,6 +424,7 @@ public abstract class AbstractSession implements Session {
                         try {
                             sendingEnquireLink.wait(500);
                         } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
                         }
                     }
                 }

--- a/jsmpp/src/main/java/org/jsmpp/session/BindRequestReceiver.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/BindRequestReceiver.java
@@ -53,7 +53,9 @@ class BindRequestReceiver {
             } else if (request == null) {
                 try {
                     requestCondition.await(timeout, TimeUnit.MILLISECONDS);
-                } catch (InterruptedException e) { }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
             }
             
             if (request != null) {

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
@@ -585,6 +585,7 @@ public class SMPPSession extends AbstractSession implements ClientSession {
 			try {
 				executorService.awaitTermination(getTransactionTimer(), TimeUnit.MILLISECONDS);
 			} catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
 				logger.warn("interrupted while waiting for executor service pool to finish");
 			}
 			logger.info("PDUReaderWorker stop");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S2142 -  "InterruptedException" should not be ignored.
You can find more information about the issue here:
`InterruptedExceptions` should never be ignored in the code, and simply logging the exception counts in this case as "ignoring". Instead, `InterruptedExceptions` should either be rethrown - immediately or after cleaning up the method's state - or the method should be reinterrupted. Any other course of action risks delaying thread shutdown and loses the information that the thread was interrupted - probably without finishing its task.

Noncompliant Code Example

`public void run () {`
`  try {`
`    while (true) { `
`      // do stuff`
`    }`
`  }catch (InterruptedException e) { // Noncompliant; logging is not enough`
`    LOGGER.log(Level.WARN, "Interrupted!", e);`
`  }`
`}`
Compliant Solution

`public void run () throws InterruptedException{`
`  try {`
`    while (true) { `
`      // do stuff`
`    }`
`  }catch (InterruptedException e) {`
`    LOGGER.log(Level.WARN, "Interrupted!", e);`
`    // clean up state...`
`    throw e;`
`  }`
`}`

or

`public void run () {`
`  try {`
`    while (true) { `
`      // do stuff`
`    }`
`  }catch (InterruptedException e) {`
`    LOGGER.log(Level.WARN, "Interrupted!", e);`
`    // clean up state...`
`    Thread.currentThread().interrupt();`
`  }`
`}`
Please let me know if you have any questions.
George Kankava