### PR TITLE
OptionalParameter:deserialize log level changed to DEBUG

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/bean/DeliveryReceipt.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/DeliveryReceipt.java
@@ -418,8 +418,12 @@ public class DeliveryReceipt {
         int day = Integer.parseInt(date.substring(4, 6));
         int hour = Integer.parseInt(date.substring(6, 8));
         int minute = Integer.parseInt(date.substring(8, 10));
+        int second = 0;
+        if (date.length() >= 12){
+            second = Integer.parseInt(date.substring(10, 12));
+        }
         Calendar cal = Calendar.getInstance();
-        cal.set(convertTwoDigitYear(year), month - 1, day, hour, minute, 0);
+        cal.set(convertTwoDigitYear(year), month - 1, day, hour, minute, second);
         cal.set(Calendar.MILLISECOND, 0);
         return cal.getTime();
     }

--- a/jsmpp/src/main/java/org/jsmpp/bean/OptionalParameters.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/OptionalParameters.java
@@ -110,7 +110,7 @@ public class OptionalParameters {
     public static OptionalParameter deserialize(short tagCode, byte[] content) {
         Tag tag = Tag.valueOf(tagCode);
         if (tag == null) {
-            logger.info("Optional Parameter Tag not recognized for deserialization: {}", tagCode);
+            logger.debug("Optional Parameter Tag not recognized for deserialization: {}", tagCode);
             return new OctetString(tagCode, content);
         }
 

--- a/jsmpp/src/test/java/org/jsmpp/util/DeliveryReceiptParserTest.java
+++ b/jsmpp/src/test/java/org/jsmpp/util/DeliveryReceiptParserTest.java
@@ -71,10 +71,32 @@ public class DeliveryReceiptParserTest {
             fail("Failed parsing delivery receipt:" + e.getMessage());
         }
     }
+
+    @Test
+    public void parseWithSecondInDate() {
+        try {
+            DeliveryReceipt delReceipt = decomposer.deliveryReceipt("id:0123456789 sub:001 dlvrd:001 submit date:080901113012 done date:080901113147 stat:DELIVRD err:000 " + ORIGINAL_MESSAGE);
+            assertEquals(delReceipt.getText(), null);
+
+            Date submitDate = delReceipt.getSubmitDate();
+            Date expectedSubmitDate = createDate(2008, 9, 1, 11, 30, 12);
+            assertEquals(submitDate, expectedSubmitDate);
+
+            Date doneDate = delReceipt.getDoneDate();
+            Date expectedDoneDate = createDate(2008, 9, 1, 11, 31, 47);
+            assertEquals(doneDate, expectedDoneDate);
+        } catch (InvalidDeliveryReceiptException e) {
+            e.printStackTrace();
+            fail("Failed parsing delivery receipt:" + e.getMessage());
+        }
+    }
     
     private static Date createDate(int year, int month, int day, int hour, int minute) {
+        return createDate(year, month, day, hour, minute, 0);
+    }
+    private static Date createDate(int year, int month, int day, int hour, int minute, int second) {
         Calendar cal = Calendar.getInstance();
-        cal.set(year, month - 1, day, hour, minute, 0);
+        cal.set(year, month - 1, day, hour, minute, second);
         cal.set(Calendar.MILLISECOND, 0);
         return cal.getTime();
     }


### PR DESCRIPTION
OptionalParameter:deserialize logging level changed to DEBUG so we can tune via log4j settings.

it makes too much noise for log4j when delivery report has unknown tag when the level is INFO