### PR TITLE
Always log caught exceptions when logging warn messages.

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/session/AbstractSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/AbstractSession.java
@@ -208,7 +208,7 @@ public abstract class AbstractSession implements Session {
             try {
                 connection().close();
             } catch (IOException e) {
-                logger.warn("Failed to close connection: {}", e.getMessage());
+                logger.warn("Failed to close connection:", e);
             }
         }
 

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPOutboundServerSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPOutboundServerSession.java
@@ -441,11 +441,11 @@ public class SMPPOutboundServerSession extends AbstractSession implements Outbou
         notifyNoActivity();
       }
       catch (IOException e) {
-        logger.warn("IOException while reading: {}", e.getMessage());
+        logger.warn("IOException while reading:", e);
         close();
       }
       catch (RuntimeException e) {
-        logger.warn("RuntimeException: {}", e.getMessage());
+        logger.warn("RuntimeException:", e);
         unbindAndClose();
       }
     }

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPOutboundSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPOutboundSession.java
@@ -452,11 +452,11 @@ public class SMPPOutboundSession extends AbstractSession implements OutboundClie
         notifyNoActivity();
       }
       catch (IOException e) {
-        logger.warn("IOException while reading: {}", e.getMessage());
+        logger.warn("IOException while reading:", e);
         close();
       }
       catch (RuntimeException e) {
-        logger.warn("RuntimeException: {}", e.getMessage());
+        logger.warn("RuntimeException:", e);
         unbindAndClose();
       }
     }

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPServerSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPServerSession.java
@@ -537,10 +537,10 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
             } catch (SocketTimeoutException e) {
                 notifyNoActivity();
             } catch (IOException e) {
-                logger.warn("IOException while reading: {}", e.getMessage());
+                logger.warn("IOException while reading:", e);
                 close();
             } catch (RuntimeException e) {
-                logger.warn("RuntimeException: {}", e.getMessage());
+                logger.warn("RuntimeException:", e);
                 unbindAndClose();
             }
         }

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
@@ -619,10 +619,10 @@ public class SMPPSession extends AbstractSession implements ClientSession {
 	        } catch (SocketTimeoutException e) {
 	            notifyNoActivity();
 	        } catch (IOException e) {
-	            logger.warn("IOException while reading: {}", e.getMessage());
+	            logger.warn("IOException while reading:", e);
 	            close();
 	        } catch (RuntimeException e) {
-			        logger.warn("RuntimeException: {}", e.getMessage());
+			        logger.warn("RuntimeException:", e);
 						  unbindAndClose();
 		      }
 	    }


### PR DESCRIPTION
We faced some connection problems that would have been easier to diagnose if caught exceptions would have been logged. Almost of the code already does this, so I changed the few places where this is handled differently.