### PR TITLE
#74 NPE in DeliveryReceipt constructor

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/bean/DeliveryReceipt.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/DeliveryReceipt.java
@@ -409,7 +409,9 @@ public class DeliveryReceipt implements DeliveryReceiptInterface<DeliveryReceipt
      *         format is less than 10.
      */
     private static Date string2Date(String date) {
-
+        if (date == null) {
+          return null;
+        }
         int year = Integer.parseInt(date.substring(0, 2));
         int month = Integer.parseInt(date.substring(2, 4));
         int day = Integer.parseInt(date.substring(4, 6));


### PR DESCRIPTION
Fixed NPE in DeliveryReceipt constructor thrown when the delivery
receipt does not have a submit date or done date.