### PR TITLE
Add command status description to NegativeResponseException (closes #76)

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/extra/NegativeResponseException.java
+++ b/jsmpp/src/main/java/org/jsmpp/extra/NegativeResponseException.java
@@ -1,5 +1,9 @@
 package org.jsmpp.extra;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.jsmpp.util.IntUtil;
 
 /**
@@ -11,6 +15,25 @@ import org.jsmpp.util.IntUtil;
  * 
  */
 public class NegativeResponseException extends Exception {
+    static {
+        HashMap<Integer, String> mapping = new HashMap<Integer, String>();
+        mapping.put(1, "Message Length is invalid");
+        mapping.put(2, "Command Length is invalid");
+        mapping.put(3, "Invalid Command ID");
+        mapping.put(4, "Incorrect BIND Status for given command");
+        mapping.put(5, "ESME Already in Bound State");
+        mapping.put(6, "Invalid Priority Flag");
+        mapping.put(7, "Invalid Registered Delivery Flag");
+        mapping.put(8, "System Error");
+        mapping.put(10, "Invalid Source Address");
+        mapping.put(11, "Invalid Destination Address");
+        mapping.put(12, "Message ID is invalid");
+        mapping.put(13, "Bind Failed");
+        mapping.put(14, "Invalid Password");
+        mapping.put(15, "Invalid System ID");
+        commandStatusToDescription = Collections.unmodifiableMap(mapping);
+    }
+    private static final Map<Integer, String> commandStatusToDescription;
     private static final long serialVersionUID = 7198456791204091251L;
     private final int commandStatus;
 
@@ -20,9 +43,18 @@ public class NegativeResponseException extends Exception {
      * @param commandStatus is the command_status.
      */
     public NegativeResponseException(int commandStatus) {
-        super("Negative response " + IntUtil.toHexString(commandStatus)
-                + " found");
+        super(createMessageForCommandStatus(commandStatus));
         this.commandStatus = commandStatus;
+    }
+
+    private static String createMessageForCommandStatus(int commandStatus) {
+        String commandStatusHex = IntUtil.toHexString(commandStatus);
+        String description = commandStatusToDescription.get(commandStatus);
+        if (description != null) {
+            return String.format("Negative response %s (%s) found", commandStatusHex, description);
+        } else {
+            return String.format("Negative response %s found", commandStatusHex);
+        }
     }
 
     /**

--- a/jsmpp/src/test/java/org/jsmpp/extra/NegativeResponseExceptionTest.java
+++ b/jsmpp/src/test/java/org/jsmpp/extra/NegativeResponseExceptionTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License"); 
+ * you may not use this file except in compliance with the License. 
+ * You may obtain a copy of the License at
+ * 
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * 
+ */
+package org.jsmpp.extra;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import org.testng.annotations.Test;
+
+public class NegativeResponseExceptionTest {
+
+    @Test
+    public void testKnownCommandStatusValue() {
+        assertThat(new NegativeResponseException(11).getMessage(), is("Negative response 0000000b (Invalid Destination Address) found"));
+    }
+
+    @Test
+    public void testUnknownCommandStatusValue() {
+        assertThat(new NegativeResponseException(400).getMessage(), is("Negative response 00000190 found"));
+    }
+}


### PR DESCRIPTION
I will add the remaining descriptions if this is judged a worthy addition. Otherwise feel free to just close this.