### PR TITLE
Uniformly use "sequence_number" for sequence numbers in logging and e…

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/session/AbstractSMPPOperation.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/AbstractSMPPOperation.java
@@ -105,7 +105,7 @@ public abstract class AbstractSMPPOperation implements SMPPOperation {
             logger.debug("{} response received", task.getCommandName() );
         } catch (ResponseTimeoutException e) {
             pendingResponse.remove(seqNum);
-            logger.debug("Response timeout for {} with sessionIdSequence number {}", task.getCommandName(), seqNum);
+            logger.debug("Response timeout for {} with sequence_number {}", task.getCommandName(), seqNum);
             throw e;
         } catch (InvalidResponseException e) {
             pendingResponse.remove(seqNum);

--- a/jsmpp/src/main/java/org/jsmpp/session/AbstractSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/AbstractSession.java
@@ -294,7 +294,7 @@ public abstract class AbstractSession implements Session {
             pendingResponse.remove(seqNum);
             throw new ResponseTimeoutException("No response after waiting for "
                     + timeout + " millis when executing "
-                    + task.getCommandName() + " with sessionId " + sessionId
+                    + task.getCommandName() + " with session " + sessionId
                     + " and sequence_number " + seqNum, e);
         } catch (InvalidResponseException e) {
             pendingResponse.remove(seqNum);

--- a/jsmpp/src/main/java/org/jsmpp/session/AbstractSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/AbstractSession.java
@@ -289,13 +289,13 @@ public abstract class AbstractSession implements Session {
 
         try {
             pendingResp.waitDone();
-            logger.debug("{} response with sequence {} received for session {}", task.getCommandName(), seqNum, sessionId);
+            logger.debug("{} response with sequence_number {} received for session {}", task.getCommandName(), seqNum, sessionId);
         } catch (ResponseTimeoutException e) {
             pendingResponse.remove(seqNum);
             throw new ResponseTimeoutException("No response after waiting for "
                     + timeout + " millis when executing "
                     + task.getCommandName() + " with sessionId " + sessionId
-                    + " and sequenceNumber " + seqNum, e);
+                    + " and sequence_number " + seqNum, e);
         } catch (InvalidResponseException e) {
             pendingResponse.remove(seqNum);
             throw e;

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPOutboundServerSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPOutboundServerSession.java
@@ -336,7 +336,7 @@ public class SMPPOutboundServerSession extends AbstractSession implements Outbou
     @Override
     public void sendDeliverSmResp(int commandStatus, int sequenceNumber, String messageId) throws IOException {
       pduSender().sendDeliverSmResp(out, commandStatus, sequenceNumber, messageId);
-      logger.debug("deliver_sm_resp with seq_number {} has been sent", sequenceNumber);
+      logger.debug("deliver_sm_resp with sequence_number {} has been sent", sequenceNumber);
     }
 
     public void sendEnquireLinkResp(int sequenceNumber) throws IOException {

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPOutboundSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPOutboundSession.java
@@ -360,7 +360,7 @@ public class SMPPOutboundSession extends AbstractSession implements OutboundClie
     @Override
     public void sendDeliverSmResp(int commandStatus, int sequenceNumber, String messageId) throws IOException {
       pduSender().sendDeliverSmResp(out, commandStatus, sequenceNumber, messageId);
-      logger.debug("deliver_sm_resp with seq_number {} has been sent", sequenceNumber);
+      logger.debug("deliver_sm_resp with sequence_number {} has been sent", sequenceNumber);
     }
 
     public void sendEnquireLinkResp(int sequenceNumber) throws IOException {

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
@@ -534,7 +534,7 @@ public class SMPPSession extends AbstractSession implements ClientSession {
 		@Override
 		public void sendDeliverSmResp(int commandStatus, int sequenceNumber, String messageId) throws IOException {
 			pduSender().sendDeliverSmResp(out, commandStatus, sequenceNumber, messageId);
-			logger.debug("deliver_sm_resp with seq_number {} has been sent", sequenceNumber);
+			logger.debug("deliver_sm_resp with sequence_number {} has been sent", sequenceNumber);
 		}
 		
 		public void sendEnquireLinkResp(int sequenceNumber) throws IOException {

--- a/jsmpp/src/main/java/org/jsmpp/session/state/AbstractGenericSMPPSessionBound.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/state/AbstractGenericSMPPSessionBound.java
@@ -131,7 +131,7 @@ abstract class AbstractGenericSMPPSessionBound implements GenericSMPPSessionStat
                         .getSequenceNumber());
             }
         } else {
-            logger.warn("No request with sequence number {} found", pduHeader.getSequenceNumber());
+            logger.warn("No request with sequence_number {} found", pduHeader.getSequenceNumber());
         }
     }
 }

--- a/jsmpp/src/main/java/org/jsmpp/session/state/SMPPOutboundServerSessionOutbound.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/state/SMPPOutboundServerSessionOutbound.java
@@ -72,7 +72,7 @@ class SMPPOutboundServerSessionOutbound implements SMPPOutboundServerSessionStat
                         message, e));
             }
         } else {
-            logger.error("No request with sequence number {} found", pduHeader.getSequenceNumber() );
+            logger.error("No request with sequence_number {} found", pduHeader.getSequenceNumber() );
             responseHandler.sendGenerickNack(
                 SMPPConstant.STAT_ESME_RINVDFTMSGID, pduHeader
                     .getSequenceNumber());

--- a/jsmpp/src/main/java/org/jsmpp/session/state/SMPPOutboundSessionBoundRX.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/state/SMPPOutboundSessionBoundRX.java
@@ -55,7 +55,7 @@ class SMPPOutboundSessionBoundRX extends SMPPOutboundSessionBound implements SMP
             DeliverSmResp resp = pduDecomposer.deliverSmResp(pdu);
             pendingResp.done(resp);
         } else {
-            logger.warn("No request with sequence number {} found", pduHeader.getSequenceNumber());
+            logger.warn("No request with sequence_number {} found", pduHeader.getSequenceNumber());
         }
     }
 }

--- a/jsmpp/src/main/java/org/jsmpp/session/state/SMPPServerSessionBoundRX.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/state/SMPPServerSessionBoundRX.java
@@ -84,7 +84,7 @@ class SMPPServerSessionBoundRX extends SMPPServerSessionBound implements
             DeliverSmResp resp = pduDecomposer.deliverSmResp(pdu);
             pendingResp.done(resp);
         } else {
-            logger.warn("No request with sequence number {} found", pduHeader.getSequenceNumber());
+            logger.warn("No request with sequence_number {} found", pduHeader.getSequenceNumber());
         }
     }
     

--- a/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionBoundTX.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionBoundTX.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  * 
  */
 class SMPPSessionBoundTX extends SMPPSessionBound implements SMPPSessionState {
-    private static final String NO_REQUEST_FIND_FOR_SEQUENCE_NUMBER = "No request find for sequence number ";
+    private static final String NO_REQUEST_FIND_FOR_SEQUENCE_NUMBER = "No request found for sequence_number ";
     private static final Logger logger = LoggerFactory.getLogger(SMPPSessionBoundTX.class);
     
     public SessionState getSessionState() {
@@ -63,7 +63,7 @@ class SMPPSessionBoundTX extends SMPPSessionBound implements SMPPSessionState {
                         .getSequenceNumber());
             }
         } else {
-            logger.warn("No request with sequence number "
+            logger.warn("No request with sequence_number "
                     + pduHeader.getSequenceNumber() + " found");
         }
     }
@@ -82,7 +82,7 @@ class SMPPSessionBoundTX extends SMPPSessionBound implements SMPPSessionState {
                         .getSequenceNumber());
             }
         } else {
-            logger.warn("No request with sequence number "
+            logger.warn("No request with sequence_number "
                     + pduHeader.getSequenceNumber() + " found");
         }
     }

--- a/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionOpen.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/state/SMPPSessionOpen.java
@@ -71,7 +71,7 @@ class SMPPSessionOpen implements SMPPSessionState {
                                 message, e));
             }
         } else {
-            logger.error("No request with sequence number {} found", pduHeader.getSequenceNumber() );
+            logger.error("No request with sequence_number {} found", pduHeader.getSequenceNumber() );
             responseHandler.sendGenerickNack(
                 SMPPConstant.STAT_ESME_RINVDFTMSGID, pduHeader
                     .getSequenceNumber());


### PR DESCRIPTION
…xception messages.

This will make searching and analyzing logs easier.

I gladly update the pull request to use a different identifier.