### PR TITLE
Fix Travis CI build by using openjdk8 and openjdk11 (instead of no th…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: java
 jdk:
-  - oraclejdk9
-  - oraclejdk8
-  - openjdk7
+  - openjdk11
+  - openjdk8


### PR DESCRIPTION
…e longer available openjdk7, oraclejdk8 and oraclejdk9 JDKs).