### PR TITLE
StrictBufferedInputStream#read: Methods overriding synchronized metho…

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/util/StrictBufferedInputStream.java
+++ b/jsmpp/src/main/java/org/jsmpp/util/StrictBufferedInputStream.java
@@ -35,7 +35,7 @@ public class StrictBufferedInputStream extends BufferedInputStream {
 
     /** Workaround for an unexpected behavior of 'BufferedInputStream'! */
     @Override
-    public int read(final byte[] buffer, final int bufPos, final int length)
+    public synchronized int read(final byte[] buffer, final int bufPos, final int length)
             throws IOException {
         int i = super.read(buffer, bufPos, length);
         if ((i == length) || (i == -1))


### PR DESCRIPTION
…ds should be synchronized, otherwise the thread-safety of the subclass may be broken.