### PR TITLE
beans for ProtocolIdentifier

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/bean/ProtocolIdentifier.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/ProtocolIdentifier.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.jsmpp.bean;
+
+import java.util.Objects;
+
+/**
+ * TP-Protocol Identifier
+ * <p/>
+ * The Protocol-Identifier is the information element by which the SM-TL either refers to the higher layer protocol being
+ * used, or indicates interworking with a certain type of telematic device.
+ * The Protocol-Identifier information element makes use of a particular field in the message types SMS-SUBMIT,
+ * SMS-SUBMIT-REPORT for RP-ACK, SMS-DELIVER DELIVER, SMS-DELIVER-REPORT for RP-ACK,
+ * SMS_STATUS_REPORT and SMS-COMMAND TP-Protocol-Identifier (TP-PID).
+ *
+ * @author <a href="mailto:kohme@gigsky.com">Karsten Ohme
+ *         (kohme@gigsky.com)</a>
+ */
+public class ProtocolIdentifier {
+
+    /**
+     * The protocol identifier group.
+     */
+    private ProtocolIdentifierGroup protocolIdentifierGroup;
+
+    /**
+     * The telematic working indicator.
+     */
+    private TelematicInterworkingIndicator telematicInterworkingIndicator;
+
+    /**
+     * The telematic device.
+     */
+    private TelematicDevice telematicDevice;
+
+    /**
+     * The protocol message type.
+     */
+    private ProtocolMessageType protocolMessageType;
+
+    /**
+     * The byte encoding of the structure.
+     */
+    private byte encoding;
+
+    private ProtocolIdentifier() {
+
+    }
+
+    /**
+     * Constructor for {@link ProtocolIdentifierGroup#_00}.
+     *
+     * @param protocolIdentifierGroup        The protocol identifier group.
+     * @param telematicInterworkingIndicator The telematic working indicator.
+     * @param telematicDevice                The telematic device.
+     */
+    public ProtocolIdentifier(ProtocolIdentifierGroup protocolIdentifierGroup, TelematicInterworkingIndicator telematicInterworkingIndicator, TelematicDevice telematicDevice) {
+        this.protocolIdentifierGroup = protocolIdentifierGroup;
+        this.telematicInterworkingIndicator = telematicInterworkingIndicator;
+        this.telematicDevice = telematicDevice;
+        encoding = (byte) (protocolIdentifierGroup.value() | telematicInterworkingIndicator.value() | telematicDevice.value());
+    }
+
+    /**
+     * Constructor for {@link ProtocolIdentifierGroup#_01}.
+     *
+     * @param protocolIdentifierGroup The protocol identifier group.
+     * @param protocolMessageType     The protocol message type.
+     */
+    public ProtocolIdentifier(ProtocolIdentifierGroup protocolIdentifierGroup, ProtocolMessageType protocolMessageType) {
+        this.protocolIdentifierGroup = protocolIdentifierGroup;
+        this.protocolMessageType = protocolMessageType;
+        encoding = (byte) (protocolIdentifierGroup.value() | protocolMessageType.value());
+    }
+
+    /**
+     * Get the byte encoding.
+     *
+     * @return the byte encoding.
+     */
+    public byte value() { return encoding; }
+
+    /**
+     * Get the protocol identifier from the byte encoding.
+     *
+     * @param encoding The encoding.
+     * @return the protocol identifier.
+     */
+    public static ProtocolIdentifier valueOf(byte encoding) {
+        ProtocolIdentifier protocolIdentifier = new ProtocolIdentifier();
+        protocolIdentifier.encoding = encoding;
+        ProtocolIdentifierGroup protocolIdentifierGroup = ProtocolIdentifierGroup.valueOf(encoding);
+        protocolIdentifier.protocolIdentifierGroup = protocolIdentifierGroup;
+        TelematicInterworkingIndicator telematicInterworkingIndicator;
+        TelematicDevice telematicDevice;
+        ProtocolMessageType protocolMessageType;
+        switch (protocolIdentifierGroup) {
+            case _00:
+                telematicInterworkingIndicator = TelematicInterworkingIndicator.valueOf(encoding);
+                protocolIdentifier.telematicInterworkingIndicator = telematicInterworkingIndicator;
+                switch (telematicInterworkingIndicator) {
+                    case INTERWORKING:
+                        telematicDevice = TelematicDevice.valueof(encoding);
+                        protocolIdentifier.telematicDevice = telematicDevice;
+                        break;
+                }
+                break;
+            case _01:
+                protocolMessageType = ProtocolMessageType.valueOf(encoding);
+                protocolIdentifier.protocolMessageType = protocolMessageType;
+                break;
+            default:
+                break;
+        }
+        return protocolIdentifier;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ProtocolIdentifier that = (ProtocolIdentifier) o;
+
+        if (protocolIdentifierGroup != that.protocolIdentifierGroup) return false;
+        if (protocolMessageType != that.protocolMessageType) return false;
+        if (telematicDevice != that.telematicDevice) return false;
+        if (telematicInterworkingIndicator != that.telematicInterworkingIndicator) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(protocolIdentifierGroup, telematicInterworkingIndicator,
+                telematicDevice, protocolMessageType);
+    }
+}

--- a/jsmpp/src/main/java/org/jsmpp/bean/ProtocolIdentifierGroup.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/ProtocolIdentifierGroup.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.jsmpp.bean;
+
+/**
+ * Protocol Identifier Group.
+ * @author <a href="mailto:kohme@gigsky.com">Karsten Ohme
+ *         (kohme@gigsky.com)</a>
+ */
+public enum ProtocolIdentifierGroup {
+    /**
+     * 00
+     */
+    _00((byte) 0),
+    /**
+     *01
+     */
+    _01((byte) 0b01000000),
+    /**
+     * Reserved
+     */
+    RESERVED((byte) 0b10000000),
+    /**
+     * Assigns bits 0-5 for SC specific use
+     */
+    SC_SPECIFIC((byte) 0b10),
+    /**
+     * SMS-SUBMIT (in the direction MS to SC)
+     */
+    SMS_SUBMIT((byte) 0b01);
+
+    /**
+     * The byte encoding of the structure.
+     */
+    private byte encoding;
+
+    private ProtocolIdentifierGroup(byte encoding) {
+        this.encoding = encoding;
+    }
+
+    /**
+     * Get the byte encoding.
+     *
+     * @return the byte encoding.
+     */
+    public byte value() { return encoding; }
+
+    /**
+     * Get the protocol identifier group from the byte encoding.
+     * You can pass the full first octet to this.
+     *
+     * @param encoding The encoding.
+     * @return the protocol identifier group.
+     */
+    public static ProtocolIdentifierGroup valueOf(byte encoding) {
+        for (ProtocolIdentifierGroup protocolIdentifierGroup : ProtocolIdentifierGroup.values()) {
+            if (protocolIdentifierGroup.encoding == (encoding & 0b11000000)) {
+                return protocolIdentifierGroup;
+            }
+        }
+        throw new IllegalArgumentException("Could not recognize protocol identifier group from encoding '" + encoding + "'.");
+    }
+}

--- a/jsmpp/src/main/java/org/jsmpp/bean/ProtocolMessageType.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/ProtocolMessageType.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.jsmpp.bean;
+
+/**
+ * Protocol message types in case {@link ProtocolIdentifierGroup#_01}.
+ * <p/>
+ * In the case where bit 7 = 0, bit 6 = 1, bits 5..0 are used as defined below
+ * 5 .. . .0
+ * 000000 Short Message Type 0
+ * 000001 Replace Short Message Type 1
+ * 000010 Replace Short Message Type 2
+ * 000011 Replace Short Message Type 3
+ * 000100 Replace Short Message Type 4
+ * 000101 Replace Short Message Type 5
+ * 000110 Replace Short Message Type 6
+ * 000111 Replace Short Message Type 7
+ * 001000 Device Triggering Short Message
+ * 001001..011101 Reserved
+ * 011110 Enhanced Message Service (Obsolete)
+ * 011111 Return Call Message
+ * 100000..111011 Reserved
+ * 111100 ANSI-136 R-DATA
+ * 111101 ME Data download
+ * 111110 ME De-personalization Short Message
+ * 111111 (U)SIM Data download
+ *
+ * @author <a href="mailto:kohme@gigsky.com">Karsten Ohme
+ *         (kohme@gigsky.com)</a>
+ */
+public enum ProtocolMessageType {
+    /**
+     * Short Message Type 0
+     */
+    SM_TYPE_0((byte) 0),
+    /**
+     * Replace Short Message Type 1
+     */
+    REPL_SM_TYPE_1((byte) 0b1),
+    /**
+     * Replace Short Message Type 2
+     */
+    REPL_SM_TYPE_2((byte) 0b10),
+    /**
+     * Replace Short Message Type 3
+     */
+    REPL_SM_TYPE_3((byte) 0b11),
+    /**
+     * Replace Short Message Type 41
+     */
+    REPL_SM_TYPE_4((byte) 0b100),
+    /**
+     * Replace Short Message Type 5
+     */
+    REPL_SM_TYPE_5((byte) 0b101),
+    /**
+     * Replace Short Message Type 6
+     */
+    REPL_SM_TYPE_6((byte) 0b110),
+    /**
+     * Replace Short Message Type 7
+     */
+    REPL_SM_TYPE_7((byte) 0b111),
+    /**
+     * Device Triggering Short Message
+     */
+    DEVICE_TRIGGERING_SM((byte) 0b001000),
+    /**
+     * Enhanced Message Service (Obsolete)
+     */
+    ENHANCED_MESSAGE_SERVICE((byte) 0b011110),
+    /**
+     * Return Call Message
+     */
+    RETURN_CALL_MESSAGE((byte) 0b11111),
+    /**
+     * ANSI-136 R-DATA
+     */
+    ANSI_136_R_DATA((byte) 0b111100),
+    /**
+     * ME Data download
+     */
+    ME_DATA_DOWNLOAD((byte) 0b110),
+    /**
+     * ME De-personalization Short Message
+     */
+    ME_DE_PERSONALIZATION_SM((byte) 0b111110),
+    /**
+     * (U)SIM Data download
+     */
+    USIM_DATA_DOWNLOAD((byte) 0b111111),
+    /**
+     * Reserved
+     */
+    RESERVED_1((byte)0b001001),
+    /**
+     * Reserved
+     */
+    RESERVED_2((byte)0b100000);
+
+    /**
+     * The byte encoding of the structure.
+     */
+    private byte encoding;
+
+    private ProtocolMessageType(byte encoding) {
+        this.encoding = encoding;
+    }
+
+    /**
+     * Get the byte encoding of the structure.
+     *
+     * @return the byte encoding of the structure.
+     */
+    public byte value() { return encoding; }
+
+    /**
+     * Get the protocol message type from the byte encoding.
+     * You can pass the full first octet to this.
+     *
+     * @param encoding The encoding.
+     * @return the protocol message type.
+     */
+    public static ProtocolMessageType valueOf(byte encoding) {
+        for (ProtocolMessageType protocolMessageType : ProtocolMessageType.values()) {
+            if (protocolMessageType.encoding == (encoding & 0b111111)) {
+                return protocolMessageType;
+            }
+        }
+        if ((encoding & RESERVED_1.encoding) == RESERVED_1.encoding) {
+            ProtocolMessageType protocolMessageType = RESERVED_1;
+            protocolMessageType.encoding = (byte) (encoding & 0b111111);
+            return protocolMessageType;
+        }
+        if ((encoding & RESERVED_2.encoding) == RESERVED_2.encoding) {
+            ProtocolMessageType protocolMessageType = RESERVED_2;
+            protocolMessageType.encoding = (byte) (encoding & 0b111111);
+            return protocolMessageType;
+        }
+        throw new IllegalArgumentException("Could not recognize protocol messaging type from encoding '" + encoding + "'.");
+    }
+}

--- a/jsmpp/src/main/java/org/jsmpp/bean/TelematicDevice.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/TelematicDevice.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.jsmpp.bean;
+
+/**
+ * Telematic Devices.
+ * <p/>
+ * In the case of telematic interworking, the following five bit patterns in bits 4..0 are used to indicate different types of
+ * telematic devices:
+ * <p/>
+ * 4.. .0
+ * 00000 implicit - device type is specific to this SC, or can be concluded on the basis of the address
+ * 00001 telex (or teletex reduced to telex format)
+ * 00010 group 3 telefax
+ * 00011 group 4 telefax
+ * 00100 voice telephone (i.e. conversion to speech)
+ * 00101 ERMES (European Radio Messaging System)
+ * 00110 National Paging system (known to the SC)
+ * 00111 Videotex (T.100 [20] /T.101 [21])
+ * 01000 teletex, carrier unspecified
+ * 01001 teletex, in PSPDN
+ * 01010 teletex, in CSPDN
+ * 01011 teletex, in analog PSTN
+ * 01100 teletex, in digital ISDN
+ * 01101 UCI (Universal Computer Interface, ETSI DE/PS 3 01-3)
+ * 01110..01111 (reserved, 2 combinations)
+ * 10000 a message handling facility (known to the SC)
+ * 10001 any public X.400-based message handling system
+ * 10010 Internet Electronic Mail
+ * 10011..10111 (reserved, 5 combinations)
+ * 11000..11110 values specific to each SC, usage based on mutual agreement between the SME and the SC
+ * (7 combinations available for each SC)
+ * 11111 A GSM/UMTS mobile station. The SC converts the SM from the received
+ * TP-Data-Coding-Scheme to any data coding scheme supported by that MS (e.g. the
+ * default).
+ *
+ * @author <a href="mailto:kohme@gigsky.com">Karsten Ohme
+ *         (kohme@gigsky.com)</a>
+ */
+public enum TelematicDevice {
+    /**
+     * implicit - device type is specific to this SC, or can be concluded on the basis of the address
+     */
+    IMPLICIT((byte) 0),
+    /**
+     * telex (or teletex reduced to telex format)
+     */
+    TELEX((byte) 0b1),
+    /**
+     * group 3 telefax
+     */
+    GRP_3_TELEFAX((byte) 0b10),
+    /**
+     * group 4 telefax
+     */
+    GRP_4_TELEFAX((byte) 0b11),
+    /**
+     * voice telephone (i.e. conversion to speech)
+     */
+    VOICE_TELEPHONE((byte) 0b100),
+    /**
+     * ERMES (European Radio Messaging System)
+     */
+    ERMES((byte) 0b101),
+    /**
+     * National Paging system (known to the SC)
+     */
+    NATIONAL_PAGING_SYSTEM((byte) 0b110),
+    /**
+     * Videotex (T.100 [20] /T.101 [21])
+     */
+    VIDEOTEX((byte) 0b111),
+    /**
+     * teletex, carrier unspecified
+     */
+    TELETEXCARRIER_UNSPECIFIED((byte) 0b1000),
+    /**
+     * teletex, in PSPDN
+     */
+    TELETEX_IN_PSPDND((byte) 0b1001),
+    /**
+     * teletex, in CSPDN
+     */
+    TELETEX_IN_CSPDN((byte) 0b1010),
+    /**
+     * teletex, in analog PSTN
+     */
+    TELETEX_ANALOG_PSTN((byte) 0b1011),
+    /**
+     * teletex, in digital ISDN
+     */
+    TELETEX_DIGITAL_ISDN((byte) 0b1100),
+    /**
+     * UCI (Universal Computer Interface, ETSI DE/PS 3 01-3)
+     */
+    UCI((byte) 0b1101),
+    /**
+     * (reserved, 2 combinations)
+     */
+   RESERVED_1((byte) 0b1110),
+    /**
+     * (reserved, 2 combinations)
+     */
+    RESERVED_2((byte) 0b1111),
+    /**
+     * a message handling facility (known to the SC)
+     */
+    MESSAGE_HANDLING_FACILITY((byte) 0b10000),
+    /**
+     * any public X.400-based message handling system
+     */
+    X_400_BASED((byte) 0b10001),
+    /**
+     * Internet Electronic Mail
+     */
+    INTERNET_ELECTRONIC_MAIL((byte) 0b10010),
+    /**
+     * (reserved, 5 combinations)
+     */
+    RESERVED_3((byte) 0b10011),
+    /**
+     * (reserved, 5 combinations)
+     */
+    RESERVED_4((byte) 0b10100),
+    /**
+     * (reserved, 5 combinations)
+     */
+    RESERVED_5((byte) 0b10101),
+    /**
+     * (reserved, 5 combinations)
+     */
+    RESERVED_6((byte) 0b10110),
+    /**
+     * (reserved, 5 combinations)
+     */
+    RESERVED_7((byte) 0b10111),
+    /**
+     * values specific to each SC, usage based on mutual agreement between the SME and the SC
+     (7 combinations available for each SC)
+     */
+    SPECIFIC_EACH_SC((byte) 0b11000),
+    /**
+     * A GSM/UMTS mobile station. The SC converts the SM from the received
+     TP-Data-Coding-Scheme to any data coding scheme supported by that MS (e.g. the
+     default).
+     */
+    GSM_UMTS((byte) 0b11111);
+
+    /**
+     * The byte encoding of the structure.
+     */
+    private byte encoding;
+
+    TelematicDevice(byte encoding) {
+        this.encoding = encoding;
+    }
+
+    /**
+     * Get the byte encoding of the structure.
+     *
+     * @return the byte encoding of the structure.
+     */
+    public byte value() { return encoding; }
+
+    /**
+     * Get the telematic device from the byte encoding.
+     * You can pass the full first octet to this.
+     *
+     * @param encoding The encoding.
+     * @return ehe telematic device.
+     */
+    public static TelematicDevice valueof(byte encoding) {
+        for (TelematicDevice telematicDevice : TelematicDevice.values()) {
+            if (telematicDevice.encoding == (encoding & 0x11111)) {
+                return telematicDevice;
+            }
+        }
+        if ((encoding & SPECIFIC_EACH_SC.encoding) == SPECIFIC_EACH_SC.encoding) {
+            TelematicDevice telematicDevice = SPECIFIC_EACH_SC;
+            telematicDevice.encoding = (byte) (encoding & 0x11111);
+            return telematicDevice;
+        }
+        throw new IllegalArgumentException("Could not recognize telematic device from encoding '" + encoding + "'.");
+    }
+}

--- a/jsmpp/src/main/java/org/jsmpp/bean/TelematicInterworkingIndicator.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/TelematicInterworkingIndicator.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+package org.jsmpp.bean;
+
+/**
+ * Telematic Interworking Indicator.
+ * <p/>
+ * bit 5 indicates telematic interworking:
+ * value = 0 : no interworking, but SME-to-SME protocol
+ * value = 1 : telematic interworking
+ *
+ * @author <a href="mailto:kohme@gigsky.com">Karsten Ohme
+ *         (kohme@gigsky.com)</a>
+ */
+public enum TelematicInterworkingIndicator {
+    /**
+     * No interworking, but SME-to-SME protocol
+     */
+    NO_INTERWORKING((byte) 0),
+    /**
+     * Telematic interworking
+     */
+    INTERWORKING((byte) 0b100000);
+
+    /**
+     * The byte encoding of the structure.
+     */
+    private byte encoding;
+
+    private TelematicInterworkingIndicator(byte encoding) {
+        this.encoding = encoding;
+    }
+
+    /**
+     * Get the byte encoding of the structure.
+     *
+     * @return the byte encoding of the structure.
+     */
+    public byte value() { return encoding; }
+
+    /**
+     * Get the telematic interworking from the byte encoding.
+     * You can pass the full first octet to this.
+     *
+     * @param encoding The encoding.
+     * @return ehe telematic interworking.
+     */
+    public static TelematicInterworkingIndicator valueOf(byte encoding) {
+        for (TelematicInterworkingIndicator sri : TelematicInterworkingIndicator.values()) {
+            if (sri.encoding == (encoding & 0x00100000)) {
+                return sri;
+            }
+        }
+        throw new IllegalArgumentException("Could not recognize telematic interworking from encoding '" + encoding + "'.");
+    }
+}


### PR DESCRIPTION
I added beans to simplify to create the protocol identifier. It would be nice if the `SMPPSession` methods could use this as typesafe argument, but this would mean that this change is not API compatible.