### PR TITLE
Fix null pointer exception on SMPPSession.queryShortMessage

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
@@ -429,7 +429,7 @@ public class SMPPSession extends AbstractSession implements ClientSession {
     QuerySmResp resp = (QuerySmResp) executeSendCommand(task,
         getTransactionTimer());
 
-    if (resp.getMessageId().equals(messageId)) {
+    if (resp.getMessageId() != null && resp.getMessageId().equals(messageId)) {
       return new QuerySmResult(resp.getFinalDate(), resp
           .getMessageState(), resp.getErrorCode());
     } else {


### PR DESCRIPTION
**Problem:**

The method `queryShortMessage` of the class `SMPPSession` compares the id of the returned message with the id passed as parameter. If they are the same, then returns the message, otherwise throws an `InvalidResponseException`. Like below:

https://github.com/opentelecoms-org/jsmpp/blob/164c0e906aac6351271e7604f813f9c1fb72b8f3/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java#L432-L439

However, there are instances where the message id of the returned message is null. In those cases this method raises an unhandled `NullPointerException`.

**Solution:**

While I do agree that this problem lies in the SMPP server, which for some reason returns the ID message as null, I think we could handle these cases a little better in this function. My proposal is just check if the message id is null before checking if it equals the parameter. Because if it is null, then it falls under the cases where the "Requested message_id doesn't match with the result".