### PR TITLE
Fixed #163. Fixed a copy paste error in OptionalParameter and exception handling in SMPPServerSession.

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/DefaultPDUSender.java
+++ b/jsmpp/src/main/java/org/jsmpp/DefaultPDUSender.java
@@ -370,9 +370,16 @@ public class DefaultPDUSender implements PDUSender {
     @Override
     public byte[] sendDataSmResp(OutputStream os, int sequenceNumber,
             String messageId, OptionalParameter... optionalParameters)
+                    throws PDUStringException, IOException {
+        return sendDataSmResp(os, SMPPConstant.STAT_ESME_ROK, messageId, optionalParameters);
+    }
+
+    @Override
+    public byte[] sendDataSmResp(OutputStream os, int commandStatus,
+            int sequenceNumber, String messageId, OptionalParameter... optionalParameters)
             throws PDUStringException, IOException {
-        byte[] b = pduComposer.dataSmResp(sequenceNumber, messageId,
-                optionalParameters);
+        byte[] b = pduComposer.dataSmResp(commandStatus, sequenceNumber,
+                messageId, optionalParameters);
         writeAndFlush(os, b);
         return b;
     }

--- a/jsmpp/src/main/java/org/jsmpp/PDUSender.java
+++ b/jsmpp/src/main/java/org/jsmpp/PDUSender.java
@@ -339,6 +339,22 @@ public interface PDUSender {
      */
     byte[] sendDataSmResp(OutputStream os, int sequenceNumber,
             String messageId, OptionalParameter... optionalParameters)
+                    throws PDUStringException, IOException;
+
+    /**
+     * Send data short message response command.
+     *
+     * @param os is the {@link OutputStream}
+     * @param commandStatus command_status
+     * @param sequenceNumber is the sequence_number
+     * @param messageId the message_id
+     * @param optionalParameters the optional parameters
+     * @return the composed bytes
+     * @throws PDUStringException if there is an invalid string constraint found
+     * @throws IOException if an input or output error occurred
+     */
+    byte[] sendDataSmResp(OutputStream os, int commandStatus,
+            int sequenceNumber, String messageId, OptionalParameter... optionalParameters)
             throws PDUStringException, IOException;
 
     /**

--- a/jsmpp/src/main/java/org/jsmpp/SynchronizedPDUSender.java
+++ b/jsmpp/src/main/java/org/jsmpp/SynchronizedPDUSender.java
@@ -326,10 +326,23 @@ public class SynchronizedPDUSender implements PDUSender {
     @Override
     public byte[] sendDataSmResp(OutputStream os, int sequenceNumber,
             String messageId, OptionalParameter... optionalParameters)
+                    throws PDUStringException, IOException {
+        return sendDataSmResp(os, SMPPConstant.STAT_ESME_ROK, sequenceNumber, messageId, optionalParameters);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.jsmpp.PDUSender#sendDataSmResp(java.io.OutputStream, int, int,
+     *      java.lang.String, org.jsmpp.bean.OptionalParameter[])
+     */
+    @Override
+    public byte[] sendDataSmResp(OutputStream os, int commandStatus,
+            int sequenceNumber, String messageId, OptionalParameter... optionalParameters)
             throws PDUStringException, IOException {
         synchronized (os) {
-            return pduSender.sendDataSmResp(os, sequenceNumber, messageId,
-                    optionalParameters);
+            return pduSender.sendDataSmResp(os, commandStatus, sequenceNumber,
+                    messageId, optionalParameters);
         }
     }
 

--- a/jsmpp/src/main/java/org/jsmpp/bean/OptionalParameter.java
+++ b/jsmpp/src/main/java/org/jsmpp/bean/OptionalParameter.java
@@ -1029,11 +1029,11 @@ public abstract class OptionalParameter {
 		 * @param value the user_response_code optional parameter
 		 */
 		public User_response_code(byte value) {
-			super(Tag.USER_MESSAGE_REFERENCE, value);
+			super(Tag.USER_RESPONSE_CODE, value);
 		}
 
 		public User_response_code(byte[] content) {
-			super(Tag.USER_MESSAGE_REFERENCE.code, content);
+			super(Tag.USER_RESPONSE_CODE.code, content);
 		}
 	}
 

--- a/jsmpp/src/main/java/org/jsmpp/session/DataSmResult.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/DataSmResult.java
@@ -14,6 +14,7 @@
  */
 package org.jsmpp.session;
 
+import org.jsmpp.SMPPConstant;
 import org.jsmpp.bean.OptionalParameter;
 import org.jsmpp.util.MessageId;
 
@@ -23,6 +24,7 @@ import org.jsmpp.util.MessageId;
  */
 public class DataSmResult {
 
+    private int commandStatus = SMPPConstant.STAT_ESME_ROK;
     private final String messageId;
     private final OptionalParameter[] optionalParameters;
 
@@ -41,5 +43,19 @@ public class DataSmResult {
 
     public OptionalParameter[] getOptionalParameters() {
         return optionalParameters;
+    }
+
+    public int getCommandStatus() {
+        return commandStatus;
+    }
+
+    /**
+     * data_sm_resp allows a non zero command_status to be sent with message_id
+     * and other optional parameters. This method allows such a non zero command_status
+     * to be set.
+     * @param commandStatus
+     */
+    public void setCommandStatus(int commandStatus) {
+        this.commandStatus = commandStatus;
     }
 }

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPOutboundServerSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPOutboundServerSession.java
@@ -330,9 +330,9 @@ public class SMPPOutboundServerSession extends AbstractSession implements Outbou
     public void sendDataSmResp(DataSmResult dataSmResult, int sequenceNumber)
         throws IOException {
       try {
-        pduSender().sendDataSmResp(out, sequenceNumber,
-            dataSmResult.getMessageId(),
-            dataSmResult.getOptionalParameters());
+        pduSender().sendDataSmResp(out, dataSmResult.getCommandStatus(),
+            sequenceNumber,
+            dataSmResult.getMessageId(), dataSmResult.getOptionalParameters());
       } catch (PDUStringException e) {
         /*
          * There should be no PDUStringException thrown since creation

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPOutboundSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPOutboundSession.java
@@ -332,9 +332,9 @@ public class SMPPOutboundSession extends AbstractSession implements OutboundClie
     public void sendDataSmResp(DataSmResult dataSmResult, int sequenceNumber)
         throws IOException {
       try {
-        pduSender().sendDataSmResp(out, sequenceNumber,
-            dataSmResult.getMessageId(),
-            dataSmResult.getOptionalParameters());
+        pduSender().sendDataSmResp(out, dataSmResult.getCommandStatus(),
+            sequenceNumber,
+            dataSmResult.getMessageId(), dataSmResult.getOptionalParameters());
       } catch (PDUStringException e) {
         /*
          * There should be no PDUStringException thrown since creation

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPServerSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPServerSession.java
@@ -515,9 +515,9 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
         public void sendDataSmResp(DataSmResult dataSmResult, int sequenceNumber)
                 throws IOException {
             try {
-                pduSender().sendDataSmResp(out, sequenceNumber,
-                        dataSmResult.getMessageId(),
-                        dataSmResult.getOptionalParameters());
+                pduSender().sendDataSmResp(out, dataSmResult.getCommandStatus(),
+                        sequenceNumber,
+                        dataSmResult.getMessageId(), dataSmResult.getOptionalParameters());
             } catch (PDUStringException e) {
                 /*
                  * There should be no PDUStringException thrown since creation

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPServerSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPServerSession.java
@@ -437,6 +437,8 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
                 throws ProcessRequestException {
             try {
                 return fireAcceptSubmitMulti(submitMulti);
+            } catch(ProcessRequestException e) {
+		throw e;
             } catch(Exception e) {
                 String msg = "Invalid runtime exception thrown when processing SubmitMultiSm";
                 log.error(msg, e);
@@ -471,6 +473,8 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
                 throws ProcessRequestException {
             try {
                 return fireAcceptQuerySm(querySm);
+            } catch(ProcessRequestException e) {
+		throw e;
             } catch(Exception e) {
                 String msg = "Invalid runtime exception thrown when processing query_sm";
                 log.error(msg, e);
@@ -528,6 +532,8 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
                 throws ProcessRequestException {
             try {
                 fireAcceptCancelSm(cancelSm);
+            } catch(ProcessRequestException e) {
+		throw e;
             } catch(Exception e) {
                 String msg = "Invalid runtime exception thrown when processing cancel_sm";
                 log.error(msg, e);
@@ -545,6 +551,8 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
                 throws ProcessRequestException {
             try {
                 fireAcceptReplaceSm(replaceSm);
+            } catch(ProcessRequestException e) {
+		throw e;
             } catch(Exception e) {
                 String msg = "Invalid runtime exception thrown when processing replace_sm";
                 log.error(msg, e);
@@ -598,6 +606,8 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
             throws ProcessRequestException {
             try {
                 fireAcceptCancelBroadcastSm(cancelBroadcastSm);
+            } catch(ProcessRequestException e) {
+		throw e;
             } catch(Exception e) {
                 String msg = "Invalid runtime exception thrown when processing cancel_broadcast_sm";
                 log.error(msg, e);
@@ -621,6 +631,8 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
                     throw new ProcessRequestException(msg, SMPPConstant.STAT_ESME_RX_R_APPN);
                 }
                 return queryBroadcastSmResult;
+            } catch(ProcessRequestException e) {
+		throw e;
             } catch(Exception e) {
                 String msg = "Invalid runtime exception thrown when processing query_broadcast_sm";
                 log.error(msg, e);
@@ -647,6 +659,8 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
         public void processEnquireLink(final EnquireLink enquireLink) {
             try {
                 fireAcceptEnquirelink(enquireLink);
+            } catch(ProcessRequestException e) {
+		throw e;
             } catch (Exception e) {
                 log.error("Invalid runtime exception thrown when processing enquire_link", e);
             }

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPServerSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPServerSession.java
@@ -438,7 +438,7 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
             try {
                 return fireAcceptSubmitMulti(submitMulti);
             } catch(ProcessRequestException e) {
-		throw e;
+                throw e;
             } catch(Exception e) {
                 String msg = "Invalid runtime exception thrown when processing SubmitMultiSm";
                 log.error(msg, e);
@@ -474,7 +474,7 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
             try {
                 return fireAcceptQuerySm(querySm);
             } catch(ProcessRequestException e) {
-		throw e;
+                throw e;
             } catch(Exception e) {
                 String msg = "Invalid runtime exception thrown when processing query_sm";
                 log.error(msg, e);
@@ -503,7 +503,7 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
             try {
                 return fireAcceptDataSm(dataSm);
             } catch(ProcessRequestException e) {
-		throw e;
+                throw e;
             } catch(Exception e) {
                 String msg = "Invalid runtime exception thrown when processing data_sm";
                 log.error(msg, e);
@@ -533,7 +533,7 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
             try {
                 fireAcceptCancelSm(cancelSm);
             } catch(ProcessRequestException e) {
-		throw e;
+                throw e;
             } catch(Exception e) {
                 String msg = "Invalid runtime exception thrown when processing cancel_sm";
                 log.error(msg, e);
@@ -552,7 +552,7 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
             try {
                 fireAcceptReplaceSm(replaceSm);
             } catch(ProcessRequestException e) {
-		throw e;
+                throw e;
             } catch(Exception e) {
                 String msg = "Invalid runtime exception thrown when processing replace_sm";
                 log.error(msg, e);
@@ -607,7 +607,7 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
             try {
                 fireAcceptCancelBroadcastSm(cancelBroadcastSm);
             } catch(ProcessRequestException e) {
-		throw e;
+                throw e;
             } catch(Exception e) {
                 String msg = "Invalid runtime exception thrown when processing cancel_broadcast_sm";
                 log.error(msg, e);
@@ -632,7 +632,7 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
                 }
                 return queryBroadcastSmResult;
             } catch(ProcessRequestException e) {
-		throw e;
+                throw e;
             } catch(Exception e) {
                 String msg = "Invalid runtime exception thrown when processing query_broadcast_sm";
                 log.error(msg, e);
@@ -659,8 +659,6 @@ public class SMPPServerSession extends AbstractSession implements ServerSession 
         public void processEnquireLink(final EnquireLink enquireLink) {
             try {
                 fireAcceptEnquirelink(enquireLink);
-            } catch(ProcessRequestException e) {
-		throw e;
             } catch (Exception e) {
                 log.error("Invalid runtime exception thrown when processing enquire_link", e);
             }

--- a/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/SMPPSession.java
@@ -580,9 +580,9 @@ public class SMPPSession extends AbstractSession implements ClientSession {
     public void sendDataSmResp(DataSmResult dataSmResult, int sequenceNumber)
         throws IOException {
       try {
-        pduSender().sendDataSmResp(out, sequenceNumber,
-            dataSmResult.getMessageId(),
-            dataSmResult.getOptionalParameters());
+        pduSender().sendDataSmResp(out, dataSmResult.getCommandStatus(),
+            sequenceNumber,
+            dataSmResult.getMessageId(), dataSmResult.getOptionalParameters());
       } catch (PDUStringException e) {
         /*
          * There should be no PDUStringException thrown since creation

--- a/jsmpp/src/main/java/org/jsmpp/util/DefaultComposer.java
+++ b/jsmpp/src/main/java/org/jsmpp/util/DefaultComposer.java
@@ -399,10 +399,22 @@ public class DefaultComposer implements PDUComposer {
     @Override
     public byte[] dataSmResp(int sequenceNumber, String messageId,
             OptionalParameter... optionalParameters) throws PDUStringException {
+        return dataSmResp(SMPPConstant.STAT_ESME_ROK, sequenceNumber, messageId, optionalParameters);
+    }
+
+    /*
+     * (non-Javadoc)
+     *
+     * @see org.jsmpp.util.PDUComposer#dataSmResp(int, int, java.lang.String,
+     *      org.jsmpp.bean.OptionalParameter[])
+     */
+    @Override
+    public byte[] dataSmResp(int commandStatus, int sequenceNumber,
+            String messageId, OptionalParameter... optionalParameters) throws PDUStringException {
         StringValidator.validateString(messageId, StringParameter.MESSAGE_ID);
 
         PDUByteBuffer buf = new PDUByteBuffer(SMPPConstant.CID_DATA_SM_RESP,
-            SMPPConstant.STAT_ESME_ROK, sequenceNumber);
+            commandStatus, sequenceNumber);
         buf.append(messageId);
         if (optionalParameters != null && optionalParameters.length > 0) {
             buf.appendAll(optionalParameters);

--- a/jsmpp/src/main/java/org/jsmpp/util/PDUComposer.java
+++ b/jsmpp/src/main/java/org/jsmpp/util/PDUComposer.java
@@ -306,6 +306,19 @@ public interface PDUComposer {
             OptionalParameter... optionalParameters) throws PDUStringException;
 
     /**
+     * Compose data short message response (data_sm_resp) PDU.
+     * @param commandStatus is the command_status.
+     * @param sequenceNumber is the sequence number.
+     * @param messageId is the the message identifier.
+     * @param optionalParameters is the optional parameter(s).
+     *
+     * @return the composed data_sm_resp PDU byte values.
+     * @throws PDUStringException if there is an invalid string constraint found
+     */
+    byte[] dataSmResp(int commandStatus, int sequenceNumber,
+            String messageId, OptionalParameter... optionalParameters) throws PDUStringException;
+
+    /**
      * Compose cancel short message (cancel_sm) PDU.
      * 
      * @param sequenceNumber Unique sequence number. The associated cancel_sm_resp PDU should echo the same sequence number.

--- a/jsmpp/src/test/java/org/jsmpp/composing/ComposeDecomposeTest.java
+++ b/jsmpp/src/test/java/org/jsmpp/composing/ComposeDecomposeTest.java
@@ -230,7 +230,7 @@ public class ComposeDecomposeTest {
 
         OptionalParameter additionalStatusInfoText = new OptionalParameter.Additional_status_info_text(new byte[]{ 0x00, 0x12, 0x34, 0x45, 0x67, 0x78});
 
-        pduSender.sendDataSmResp(out, 1234, "41fbf22d-fb3b-49ac-9c5e-71b762158808", additionalStatusInfoText);
+        pduSender.sendDataSmResp(out, SMPPConstant.STAT_ESME_ROK, 1234, "41fbf22d-fb3b-49ac-9c5e-71b762158808", additionalStatusInfoText);
 
         DataInputStream in = new DataInputStream(new ByteArrayInputStream(out.toByteArray()));
         Command header = pduReader.readPDUHeader(in);


### PR DESCRIPTION
OptionalParameter.java: User_response_code uses USER_MESSAGE_REFERENCE tag. Seems to be missed while copy paste from previous User_message_reference.
SMPPServerSession.java: When a ProcessRequestException is thrown by the client application, it should not be wrapped in a new ProcessRequestException. This seems to be done for processSubmitSm and processDataSm but missed for other process() methods.