### PR TITLE
Fix deadlocks when trying to a close a session from a session state listener

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/session/AbstractSession.java
+++ b/jsmpp/src/main/java/org/jsmpp/session/AbstractSession.java
@@ -272,11 +272,10 @@ public abstract class AbstractSession implements Session, Closeable {
                     log.warn("Interrupted while waiting for enquireLinkSender thread to exit");
                 }
             }
-        }
-
-        if (!sessionState.equals(SessionState.CLOSED)) {
-            log.debug("Close session context {} in state {}", sessionId, sessionState);
-            ctx.close();
+            if (!sessionState.equals(SessionState.CLOSED)) {
+                log.debug("Close session context {} in state {}", sessionId, sessionState);
+                ctx.close();
+            }
         }
     }
 


### PR DESCRIPTION
I was able to fix the testcode in #193 with the patches in this PR.

If you think the `ReadWriteLock` approach is the right way to go forward with, I would replicate it into the other subclasses of AbstractSessionContext.
