### PR TITLE
Remove Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,0 @@
-language: java
-jdk:
-  - openjdk11
-  - openjdk8

--- a/README.md
+++ b/README.md
@@ -12,11 +12,6 @@ jSMPP is not a high-level library. People looking for a quick way to
 get started with SMPP may be better of using an abstraction layer such
 as the Apache Camel SMPP component [Apache Camel SMPP component](https://camel.apache.org/smpp.html)
 
-Travis-CI status:
------------------
-
-[![Build Status](https://travis-ci.com/opentelecoms-org/jsmpp.svg?branch=master)](https://travis-ci.com/opentelecoms-org/jsmpp)
-
 History
 -------
 


### PR DESCRIPTION
As it is dead, it should be removed.

I can create a pull request to set-up github actions as a replacement if you like.