### PR TITLE
add "ESME_RCNTSUBDL" into SMPP error codes table

### DIFF
--- a/jsmpp/src/main/java/org/jsmpp/extra/NegativeResponseException.java
+++ b/jsmpp/src/main/java/org/jsmpp/extra/NegativeResponseException.java
@@ -46,6 +46,7 @@ public class NegativeResponseException extends Exception {
         // 65 is reserved
         mapping.put(66, "Invalid 'submit with replace' request");
         mapping.put(67, "Invalid esm_class field data");
+        mapping.put(68, "Cannot submit to a distribution list");
         mapping.put(69, "submit_sm or submit_multi failed");
         // 70 - 71 are reserved
         mapping.put(72, "Invalid Source address TON");


### PR DESCRIPTION
When I received an _ESME_RCNTSUBDL_, I found that it could not be serialized into the (status) description format. Because _ESME_RCNTSUBDL_ is missing from the error table. It is supported in the standard smpp protocol.
I thought there might be some reason why he missed it.
![image](https://github.com/opentelecoms-org/jsmpp/assets/25655255/9510c11d-b931-45e8-9a53-61398f5b4768)

for [https://github.com/opentelecoms-org/jsmpp/issues/227](https://github.com/opentelecoms-org/jsmpp/issues/227)
